### PR TITLE
Dev candidates iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ For examples, see the `bin` folder. There are two example binaries.
 ## Roadmap
 
 - [x] Candidate iterator with fine-grained control over sampling
+- [ ] Examples for new Candidate API.
+- [ ] Support for chaining sampling methods using `SampleOptions`. `mode` will
+      become `modes` and applied one after another until only a single
+      Candidate token remains.
 - [ ] Common command line options for sampling. Currently this is not exposed.
 - [ ] API closer to Ollama. Potentially support for something like `Modelfile`.
 - [ ] Logging (non-blocking) and benchmark support.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For examples, see the `bin` folder. There are two example binaries.
 
 ## Roadmap
 
+- [x] Candidate iterator with fine-grained control over sampling
 - [ ] Common command line options for sampling. Currently this is not exposed.
 - [ ] API closer to Ollama. Potentially support for something like `Modelfile`.
 - [ ] Logging (non-blocking) and benchmark support.
@@ -36,7 +37,6 @@ For examples, see the `bin` folder. There are two example binaries.
 - [ ] Web server. Tokenization in the browser.
 - [ ] Tiktoken as the tokenizer for some models instead of llama.cpp's internal one.
 - [ ] Reworked, functional, public, candidate API
-- [ ] Candidate iterator with fine-grained control over sampling
 - [ ] Grammar constraints (maybe or maybe not [`llama.cpp`] style)
 - [ ] Async streams, better parallelism with automatic batch scheduling
 - [ ] Backends other than [`llama.cpp`] (eg. [MLC](https://github.com/twiceyuan/mlc-llm-llama2), [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM), [Ollama](https://github.com/pepperoni21/ollama-rs))

--- a/bin/dittomancer/dittomancer.rs
+++ b/bin/dittomancer/dittomancer.rs
@@ -281,7 +281,7 @@ async fn main() -> () {
         }
 
         let mut opts = PredictOptions::default()
-            .add_model_eos(&engine.model)
+            .add_model_stops(&engine.model)
             .add_stop_sequence(vec![13])
             // We should stop at the username prompt.
             .add_stop(&format!("\n{}:", prompt.human), &engine.model);

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -92,6 +92,11 @@ impl Batch {
         self.batch.n_tokens as usize
     }
 
+    /// Returns true if batch is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// The size of each embedding.
     pub const fn embd_len(&self) -> usize {
         self.embd_len

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod batch;
 pub(crate) use batch::Batch;
 
 mod candidates;
-pub use candidates::{Candidates, Sorted};
+pub use candidates::{Candidates, Sorted, TokenDataArray};
 
 pub mod prompt;
 pub use prompt::{Message, Prompt, Role};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// TODO: Importing everything from the submodules is fine for small crates, but
+// this is getting crowded. When we go to version 0.2.0, we should consider
+// making modules public.
+
 #[cfg(feature = "cli")]
 pub mod cli;
 
@@ -15,7 +19,7 @@ mod batch;
 pub(crate) use batch::Batch;
 
 mod candidates;
-pub(crate) use candidates::Candidates;
+pub use candidates::{Candidates, Sorted};
 
 pub mod prompt;
 pub use prompt::{Message, Prompt, Role};
@@ -30,7 +34,7 @@ mod engine;
 pub use engine::Engine;
 
 mod predictor;
-pub use predictor::{PredictOptions, Predicted, Predictor};
+pub use predictor::{CandidatePredictor, PredictOptions, TokenPredictor};
 
 mod probability;
 pub use probability::{InvalidProbability, Probability};

--- a/src/model.rs
+++ b/src/model.rs
@@ -28,7 +28,7 @@ mod vocab;
 pub use vocab::Vocab;
 pub use vocab::VocabKind;
 
-use crate::{Message, Prompt};
+use crate::Prompt;
 
 /// Convert a token to it's string representation.
 ///

--- a/src/model.rs
+++ b/src/model.rs
@@ -28,6 +28,8 @@ mod vocab;
 pub use vocab::Vocab;
 pub use vocab::VocabKind;
 
+use crate::{Message, Prompt};
+
 /// Convert a token to it's string representation.
 ///
 /// Adapted from `llama.cpp/common/common.cpp`
@@ -467,7 +469,17 @@ impl Model {
             }
         };
 
-        return String::from_utf8(buf).ok();
+        match String::from_utf8(buf).ok() {
+            Some(mut s) => {
+                // strip null terminators
+                while s.ends_with('\0') {
+                    let _ = s.pop();
+                }
+
+                Some(s)
+            }
+            None => None,
+        }
     }
     /// Get a tensor by name.
     pub fn get_tensor<'a>(&'a self, name: &str) -> Option<&'a ggml_tensor> {
@@ -631,65 +643,70 @@ impl Model {
         self.tokens_to_pieces(tokens).collect()
     }
 
-    /// Apply chat template. Inspired by hf `apply_chat_template` in Python.
+    /// Apply chat template to a [`Prompt`] using `llama.cpp`'s
+    /// `llama_chat_apply_template`. If template is `None`, the model's default
+    /// template is used (metadata key `tokenizer.chat_template`).
     ///
-    /// # Panics
-    /// * If the message strings are not valid UTF-8.
+    /// This can return `None` if the template is not supported by llama.cpp.
+    /// This is equivalent to a return code of -1 from the C++ function. In this
+    /// case, use one of the [`Prompt::format`] methods which cannot fail.
     ///
-    /// Safety:
-    /// * The caller must ensure that the message strings are null-terminated.
-    ///
-    /// # Arguments
-    /// * `template` - Jinja chat template. If this is None, the model's default
-    ///   template will be used.
-    /// * `messages` - Chat messages to apply as examples.
-    /// * `add_ass` - Whether to end the prompt with the token(s) indicating the
-    ///   start of the assistant's response.
-    // TODO: make safe by wrapping the messages in a struct that maintains the
-    // invariant that everything is null-terminated. Or we could create our own
-    // message struct and then reference it's data.
-    pub unsafe fn apply_chat_template(
+    /// `add_ass` is a boolean that determines whether to add the assistant's
+    /// prefix to the output. This forces the model to generate the next message
+    /// from the assistant's perspective which is usually the desired behavior.
+    pub fn apply_chat_template(
         &self,
         template: Option<&str>,
-        messages: &[llama_chat_message],
+        prompt: &Prompt,
         add_ass: bool,
-    ) -> String {
+    ) -> Option<String> {
         let template = template.map(|s| CString::new(s).unwrap());
         let template_ptr = template
             .map(|s| s.as_bytes_with_nul().as_ptr() as *const c_char)
+            // the model's default will be used if template_ptr is null
             .unwrap_or(std::ptr::null_mut());
 
         // The recommended buffer allocation size is the number of characters in
         // the input messages * 2. This seems like overkill.
         let mut buf_len = 0;
-        for message in messages {
-            // for each message, count the chars in role and content until the
-            // null terminator
-            let role_len = CStr::from_ptr(message.role).to_bytes().len();
-            let message_len = CStr::from_ptr(message.content).to_bytes().len();
+        let mut messages: Vec<llama_chat_message> = Vec::new();
+        for message in &prompt.transcript {
+            let role = CString::new(match message.role {
+                crate::Role::Human => prompt.human.as_bytes(),
+                crate::Role::Agent => prompt.agent.as_bytes(),
+                crate::Role::System => match &prompt.system {
+                    Some(system) => system.as_bytes(),
+                    // FIXME: System's name is a per-model thing, but it's not
+                    // available on the model metadata. We do need to guess at
+                    // this. This is a temporary solution. `Prompt` should use
+                    // heuristics to determine the system's name.
+                    None => "system".as_bytes(),
+                },
+            })
+            .unwrap();
 
-            buf_len += role_len + message_len
+            let text = CString::new(message.text.as_bytes()).unwrap();
+
+            buf_len += text.as_bytes().len();
+            buf_len += role.as_bytes().len();
+
+            // We are leaking memory here. We need to clean up after we're done
+            // with the call to `llama_chat_apply_template`.
+            messages.push(llama_chat_message {
+                role: role.into_raw(),
+                content: text.into_raw(),
+            });
         }
-        buf_len *= 2;
 
         let mut buf = vec![0u8; buf_len];
 
-        let required_len: usize = llama_chat_apply_template(
-            self.inner,
-            template_ptr,
-            messages.as_ptr(),
-            messages.len(),
-            add_ass,
-            buf.as_mut_ptr() as *mut c_char,
-            buf.len() as i32,
-        )
-        .try_into()
-        .unwrap();
-
-        if required_len > buf_len {
-            buf.resize(required_len, 0);
-
-            let check: usize = llama_chat_apply_template(
+        // Safety: The messages are valid UTF-8, null terminated, and outlive
+        // the function call. It is very likely that the buffer will be too
+        // small. We'll resize it and call the function again. This is fine
+        // because the function will return the required length and not overflow
+        // the buffer.
+        let ret = unsafe {
+            llama_chat_apply_template(
                 self.inner,
                 template_ptr,
                 messages.as_ptr(),
@@ -698,15 +715,48 @@ impl Model {
                 buf.as_mut_ptr() as *mut c_char,
                 buf.len() as i32,
             )
+        };
+
+        // This is actually undocumented in the C++ docs, but this is what
+        // happens when a tempate is unsupported by llama.cpp.
+        if ret == -1 {
+            return None;
+        }
+
+        // If the return is positive, it is the required length.
+        let required_len: usize = ret.try_into().unwrap();
+
+        if required_len > buf_len {
+            buf.resize(required_len, 0);
+
+            let check: usize = unsafe {
+                llama_chat_apply_template(
+                    self.inner,
+                    template_ptr,
+                    messages.as_ptr(),
+                    messages.len(),
+                    add_ass,
+                    buf.as_mut_ptr() as *mut c_char,
+                    buf.len() as i32,
+                )
+            }
             .try_into()
             .unwrap();
 
             assert!(check == required_len)
         }
 
-        buf.resize(required_len, 0);
+        // Free the messages.
+        for message in messages {
+            // Safety: we just created these pointers above with
+            // `CString::into_raw`. We are taking ownership to free the strings.
+            unsafe {
+                _ = CString::from_raw(message.role as *mut i8);
+                _ = CString::from_raw(message.content as *mut i8);
+            }
+        }
 
-        String::from_utf8(buf).unwrap()
+        Some(String::from_utf8(buf).unwrap())
     }
 
     /// Get text for a given token.
@@ -768,7 +818,7 @@ impl Drop for Model {
 
 #[cfg(test)]
 mod tests {
-    use llama_cpp_sys_3::llama_vocab_type_LLAMA_VOCAB_TYPE_SPM;
+    use llama_cpp_sys_3::llama_vocab_type_LLAMA_VOCAB_TYPE_BPE;
 
     use super::*;
 
@@ -777,91 +827,106 @@ mod tests {
         use std::path::PathBuf;
 
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        // This should be a properly converted llama 2 model or this test will
+        // This should be a properly converted llama 3 model or this test will
         // fail.
         path.push("models/model.gguf");
 
         let model = Model::from_file(path, None).unwrap();
 
-        assert_eq!(model.bos(), 1);
-        assert_eq!(model.eos(), 2);
-        assert_eq!(model.next_line(), 13);
-        // these are for CodeLLama
+        assert_eq!(model.bos(), 128000);
+        assert_eq!(model.eos(), 128001);
+        assert_eq!(model.next_line(), 128);
+        // These are for CodeLLama. These are included in the conversion of the
+        // llama 3 model I am using but these are wrong. They are for llama 2.
+        // TODO: Wait for a proper conversion and adjust these values.
         assert_eq!(model.infill_prefix(), 32007);
         assert_eq!(model.infill_suffix(), 32008);
-
         assert_eq!(model.infill_middle(), 32009);
         assert_eq!(model.eot(), 32010);
         assert_eq!(model.add_bos(), None);
         assert_eq!(model.add_eos(), None);
-        assert_eq!(model.vocab_type(), llama_vocab_type_LLAMA_VOCAB_TYPE_SPM);
-        assert_eq!(model.n_vocab(), 32000);
-        assert_eq!(model.context_size(), 4096);
+        assert_eq!(model.vocab_type(), llama_vocab_type_LLAMA_VOCAB_TYPE_BPE);
+        assert_eq!(model.n_vocab(), 128256);
+        assert_eq!(model.context_size(), 8192);
         assert_eq!(model.embedding_size(), 8192);
         assert_eq!(model.rope_type(), 0);
         assert_eq!(model.rope_freq_scale(), 1.0);
         let desc = model.desc().to_lowercase();
         assert!(desc.starts_with("llama"));
-        assert_eq!(model.meta_count(), 16);
+        assert_eq!(model.meta_count(), 18);
+        assert_eq!(
+            model.get_meta("tokenizer.chat_template").unwrap(),
+            "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }".to_owned()
+        );
         // The model size will be different on different systems, but the range
         // should be reasonable. Not zero and not over 200GB.
         assert!(model.size() > 8192 && model.size() < 200_000_000_000);
-        // LLama v2 variants come between 7 and 70 billion parameters
+        // LLama v3 variants come between 7 and 70 billion parameters give or
+        // take.
         assert!(
-            model.n_params() > 7_000_000_000
-                && model.n_params() < 70_000_000_000
+            model.n_params() > 6_000_000_000
+                && model.n_params() < 80_000_000_000
         );
 
-        let meta = model.meta();
-        assert_eq!(meta.len(), 16);
+        // let meta = model.meta();
+        // assert_eq!(meta.len(), 16);
 
         // test tokenization
         const EXPECTED: &str = "Hello, world!";
         let tokens = model.tokenize(EXPECTED, false);
-        assert_eq!(tokens, &[15043, 29892, 3186, 29991]);
-        assert_eq!(
-            model.tokens_to_string(tokens).strip_prefix(" ").unwrap(),
-            EXPECTED
-        );
+        assert_eq!(tokens, &[9906, 11, 1917, 0]);
+        assert_eq!(model.tokens_to_string(tokens), EXPECTED);
 
         // test get token text
-        assert_eq!(model.token_to_text(15043), "▁Hello");
+        assert_eq!(model.token_to_text(9906), "Hello");
         assert_eq!(
             model
-                .tokens_to_text(&[15043, 29892, 3186, 29991])
+                .tokens_to_text(&[9906, 11, 1917, 0])
                 .collect::<Vec<_>>(),
-            &["▁Hello", ",", "▁world", "!"]
+            &["Hello", ",", "Ġworld", "!"]
         );
 
         // test template application
-        let messages = [
-            llama_chat_message {
-                role: CString::new("user").unwrap().into_raw(),
-                content: CString::new("Hello, world!").unwrap().into_raw(),
+        let messages = vec![
+            Message {
+                role: crate::Role::Human,
+                text: "Hello, world!".to_string(),
             },
-            llama_chat_message {
-                role: CString::new("assistant").unwrap().into_raw(),
-                content: CString::new("Hi!").unwrap().into_raw(),
+            Message {
+                role: crate::Role::Agent,
+                text: "Hi!".to_string(),
             },
-            llama_chat_message {
-                role: CString::new("user").unwrap().into_raw(),
-                content: CString::new("So, how's it going?")
-                    .unwrap()
-                    .into_raw(),
+            Message {
+                role: crate::Role::Human,
+                text: "So, how's it going?".to_string(),
             },
         ];
-        let result =
-            unsafe { model.apply_chat_template(None, &messages, true) };
+
+        let prompt = crate::Prompt {
+            human: "user".to_string(),
+            agent: "assistant".to_string(),
+            system: None,
+            transcript: messages,
+            setting: Some(
+                "A conversation between a user and an assistant.".to_string(),
+            ),
+        };
+
+        // FIXME: The model currently testing with has a jinja2 template that
+        // is not supported by llama.cpp. The code in llama.cpp is not actually
+        // a jinja parser. It relies on heuristics and will fail if the template
+        // is not recognized. This will fail until LLama3 support is released,
+        // however, the code is believed to be correct.
+        //
+        // In the meantime we might want to fall back to our own formatting
+        // methods in cases where the template is not supported.
+        let template = model.get_meta("tokenizer.chat_template").unwrap();
+        let result = model
+            .apply_chat_template(Some(&template), &prompt, true)
+            .unwrap();
         assert_eq!(
             result,
             "<|im_start|>user\nHello, world!<|im_end|>\n<|im_start|>assistant\nHi!<|im_end|>\n<|im_start|>user\nSo, how's it going?<|im_end|>\n<|im_start|>assistant\n",
         );
-        for message in messages {
-            let llama_chat_message { role, content } = message;
-            unsafe {
-                let _ = CString::from_raw(role as *mut c_char);
-                let _ = CString::from_raw(content as *mut c_char);
-            }
-        }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -233,6 +233,18 @@ impl Model {
         unsafe { llama_token_suffix(self.inner) }
     }
 
+    /// Calculate the longest token length. Useful for optimizing searches.
+    ///
+    /// Time complexity is O(k) where k is the vocab size.
+    pub fn max_token_len(&self) -> usize {
+        let mut max_len = 0;
+        for i in 0..self.n_vocab() {
+            max_len = max_len.max(self.token_to_text(i).len());
+        }
+
+        max_len
+    }
+
     /// Return whether BOS token is enabled.
     ///
     /// Returns None if unknown.

--- a/src/predictor.rs
+++ b/src/predictor.rs
@@ -1,11 +1,11 @@
 use std::num::{NonZeroU128, NonZeroUsize};
 
 use llama_cpp_sys_3::llama_token;
-use xorshift::SeedableRng;
+use xorshift::{SeedableRng, Xoroshiro128};
 
 use crate::{
-    ngram::NGramStats, sample::SampleOptions, Batch, Candidates, Engine, Model,
-    NGram,
+    batch::AddError, ngram::NGramStats, prompt::Format, sample::SampleOptions,
+    Batch, Candidates, Engine, Model, NGram,
 };
 
 #[cfg(feature = "serde")]
@@ -95,23 +95,49 @@ impl Default for PredictOptions {
 impl PredictOptions {
     const DEFAULT_SEED: NonZeroU128 = match NonZeroU128::new(1337) {
         Some(seed) => seed,
-        None => panic!("Failed to create a non-zero seed."),
+        None => panic!("Bad seed."),
     };
 
-    /// Add the model's end-of-sequence token to the stop sequences and any
-    /// ignored n-grams if repetition penalties are enabled.
-    pub fn add_model_eos(mut self, model: &Model) -> Self {
-        self = self.add_stop_sequence(vec![model.eos()]);
+    /// Add any stop tokens from the model. If there is an associated
+    /// [`prompt::Format`], the stop tokens will be added. *Otherwise*, the EOS
+    /// from [`Model::eos`] will be added (not both).
+    ///
+    /// To force the inclusion of the EOS token, use [`add_stop_sequence`] with
+    /// [`Model::eos`].
+    pub fn add_model_stops(mut self, model: &Model) -> Self {
+        if let Some(format) = Format::from_model(model) {
+            self = self.add_stop_format(format);
+        } else {
+            // eos is already included if a stop format is found.
+            self = self.add_stop_sequence(vec![model.eos()]);
 
-        if let Some(opts) = &mut self.sample_options.repetition {
-            opts.ignored.push(model.eos().into());
+            if let Some(opts) = &mut self.sample_options.repetition {
+                opts.ignored.push(model.eos().into());
+            }
+        }
+
+        self
+    }
+
+    /// Add stop sequences for a given [`prompt::Format`]
+    ///
+    /// [`prompt::Format`]: crate::prompt::Format
+    pub fn add_stop_format(mut self, format: Format) -> Self {
+        if let Some(stop_tokens) = format.stop_tokens() {
+            for &stop_token in stop_tokens {
+                self.stop_sequences.push(vec![stop_token]);
+                if let Some(opts) = &mut self.sample_options.repetition {
+                    opts.ignored.push(stop_token.into());
+                }
+            }
         }
 
         self
     }
 
     /// Add a stop sequence of tokens. If the [`Predictor`] reaches any of these
-    /// sequences, it will stop predicting.
+    /// sequences, it will stop predicting. The stop sequence will be included
+    /// in the tokens.
     pub fn add_stop_sequence(mut self, sequence: Vec<llama_token>) -> Self {
         self.stop_sequences.push(sequence);
 
@@ -119,84 +145,149 @@ impl PredictOptions {
     }
 
     /// Add a stop sequence by string. If the [`Predictor`] reaches any of these
-    /// sequences, it will stop predicting. Special tokens are not allowed. One
-    /// should keep in mind that the string representation of the special tokens
-    /// may not exactly match the string representation of the token. As such,
-    /// it is recommended to use [`Self::add_stop_sequence`] with the token
-    /// values directly.
-    ///
-    /// # Notes
-    /// * Pieces can be previewed with [`Model::token_to_piece`] and other
-    /// `Model::token_to_*` functions.
-    pub fn add_stop(mut self, sequence: &str, _model: &Model) -> Self {
-        // let tokens = model.tokenize(sequence, false);
-        // FIXME: This won't work because the tokens won't match. We need to
-        // Somehow make sure the string representation of the tokens matches the
-        // detokenized string. For now we can just use the string directly.
+    /// sequences, it will stop predicting. The stop sequence will be included
+    /// in the text.
+    pub fn add_stop(mut self, s: String) -> Self {
+        self.stop_strings.push(s);
 
-        // self.add_stop_sequence(tokens)
-        self.stop_strings.push(sequence.to_owned());
+        self
+    }
+
+    /// Add a stop sequence by regex. If the [`Predictor`] reaches any of these
+    /// sequences, it will stop predicting once the regex matches the text.
+    pub fn add_stop_regex(mut self, regex: regex::Regex) -> Self {
+        self.regex_stop_sequences.push(regex);
 
         self
     }
 }
-
-/// A prediction.
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
-pub struct Predicted {
-    /// The predicted token.
-    pub token: llama_token,
-    /// The piece of text that the token represents
-    pub piece: String,
-}
-
 /// An iterator that predicts a sequence of tokens until the end of the sequence
 /// is reached.
-pub struct Predictor<'engine, 'tokens> {
+pub struct CandidatePredictor<'engine> {
     /// The inference engine.
-    engine: &'engine mut Engine,
+    pub engine: &'engine mut Engine,
     /// The tokens to predict.
-    tokens: &'tokens mut Vec<llama_token>,
-    /// Decoded text (temporary)
-    text: String,
-    /// The random number generator.
-    rng: xorshift::Xoroshiro128,
-    /// Candidates for the next token.
-    // TODO: We can have a Vec of candidates to implement beam search and more.
-    candidates: Candidates,
+    pub tokens: Vec<llama_token>,
     /// The batch of tokens.
-    batch: Batch,
-    /// Prediction options.
-    options: PredictOptions,
-    /// NGram store for statistics and penalties.
-    ngram_stats: NGramStats,
+    pub batch: Batch,
     /// The current index in the batch.
-    n_cur: usize,
+    pub n_cur: usize,
     /// The number of tokens that have been decoded.
-    n_decode: usize,
-    /// The mu value for Mirostat sampling.
-    mu: Option<f32>,
+    pub n_decode: usize,
+    /// The number of tokens to generate
+    pub n: NonZeroUsize,
 }
 
-impl<'engine, 'tokens> Predictor<'engine, 'tokens> {
-    /// Create a new `PredictIter`.
+impl<'engine> CandidatePredictor<'engine> {
+    /// Create a new `CandidatePredictor` that predicts `n` [`Candidates`]
+    /// containers.
     ///
     /// # Panics
     /// * If the model's n_vocab is not between 1 and i32::MAX.
     pub fn new(
         engine: &'engine mut Engine,
-        tokens: &'tokens mut Vec<llama_token>,
+        tokens: Vec<llama_token>,
+        n: NonZeroUsize,
+    ) -> Self {
+        // FIXME: We don't need a batch this large. We can do the first decode
+        // here and then use the batch size of 1 from then on. This is
+        // especially true now that the c++ api has async decoding and the
+        // decode is not blocking. It's also possible the engine could allow
+        // multiple predictions at once and batch them together, but that would
+        // require a lot of work.
+        // NOTE: There is work going on right now in llama.cpp to rework the
+        // batch system to be more efficient. This will likely change in the
+        // future.
+        let batch_capacity =
+            (n.get() + tokens.len()).min(engine.n_ctx() as usize);
+        let batch = Batch::from_tokens(batch_capacity, &tokens).unwrap();
+        let n_cur = batch.batch.n_tokens as usize;
+
+        // TODO: async decode was just added to the c++ api. We should start the
+        // decode here and lazily get the logits as we need them.
+        Self {
+            tokens,
+            engine,
+            batch,
+            n_cur,
+            n_decode: 0,
+            n,
+        }
+    }
+
+    /// Record the choice of a token. This adds the token to the batch and
+    /// tokens. If it's not possible (because the batch is too small. etc.) an
+    /// error is returned.
+    pub fn record_choice(
+        &mut self,
+        token: llama_token,
+    ) -> Result<(), AddError> {
+        self.batch.add_token(token, self.n_cur, None, true)?;
+        self.tokens.push(token);
+
+        Ok(())
+    }
+}
+
+impl<'engine> Iterator for CandidatePredictor<'engine> {
+    type Item = Candidates;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.n_decode == self.n.get()
+            || self.n_cur >= self.engine.n_ctx() as usize
+        {
+            return None;
+        }
+
+        let batch = &mut self.batch;
+
+        // If the batch is empty, we will stop prediction because if we call
+        // decode with an empty batch, it will return an error.
+        if batch.is_empty() {
+            return None;
+        }
+
+        // Decode the next token
+        self.engine.decode(batch).unwrap();
+
+        // Get the logits for the next token
+        let logits = self.engine.logits(batch.len() - 1);
+
+        // Create or fill existing candidates from the logits
+        let candidates = Candidates::from_logits(logits.iter().cloned());
+
+        batch.clear();
+
+        self.n_cur += 1;
+        self.n_decode += 1;
+
+        Some(candidates)
+    }
+}
+
+impl<'engine> Into<Vec<llama_token>> for CandidatePredictor<'engine> {
+    fn into(self) -> Vec<llama_token> {
+        self.tokens
+    }
+}
+
+pub struct TokenPredictor<'engine> {
+    rng: Xoroshiro128,
+    ngram_stats: NGramStats,
+    options: PredictOptions,
+    pub text: String,
+    pub(crate) max_stop_len: usize,
+    /// Mu value for Mirostat sampling
+    mu: Option<f32>,
+    pub(crate) inner: CandidatePredictor<'engine>,
+}
+
+impl<'engine> TokenPredictor<'engine> {
+    pub fn new(
+        engine: &'engine mut Engine,
+        tokens: Vec<llama_token>,
         mut options: PredictOptions,
     ) -> Self {
-        // This can't panic unless the model is broken and has a vocab size of
-        // 0 or > i32::MAX.
-        let mut candidates =
-            Candidates::new(engine.model.n_vocab() as usize).unwrap();
-
-        // TODO: we can reduce memory usage for the batch here since the size
-        // is always 1 after the initial decode.
-        let batch_capacity = options.n.get() + tokens.len();
         // convert seed from a u128 to [u64; 2] to seed the rng
         let seed = match options.seed {
             Some(seed) => seed,
@@ -225,19 +316,13 @@ impl<'engine, 'tokens> Predictor<'engine, 'tokens> {
                 seed[14], seed[15],
             ]),
         ];
-        // FIXME: We don't need a batch this large. We can do the first decode
-        // here and then use the batch size of 1 from then on. This is
-        // especially true now that the c++ api has async decoding and the
-        // decode is not blocking. It's also possible the engine could allow
-        // multiple predictions at once and batch them together, but that would
-        // require a lot of work.
-        // NOTE: There is work going on right now in llama.cpp to rework the
-        // batch system to be more efficient. This will likely change in the
-        // future.
-        let batch = Batch::from_tokens(batch_capacity, tokens).unwrap();
-        let n_cur = batch.batch.n_tokens as usize;
 
         let mut ngram_stats = NGramStats::new();
+        // Dummy candidates to start. TODO: Rethink this. Ngram stats are
+        // supposed to include data like cumulative probabilities, but we don't
+        // have that here, although we could calculate them from the tokens.
+        let candidates =
+            Candidates::new(engine.model.n_vocab() as usize).unwrap();
         // Init ngram stats
         if let Some(opts) = &mut options.sample_options.repetition {
             for win in tokens.windows(opts.ngram_max_size.get().into()) {
@@ -246,53 +331,57 @@ impl<'engine, 'tokens> Predictor<'engine, 'tokens> {
                     .filter_map(|n| win.get((win.len() - n as usize)..))
                 {
                     let ngram = NGram::try_from_tokens(slice).unwrap();
-                    _ = ngram_stats.add(ngram, &mut candidates)
+                    let _ = ngram_stats.add(ngram, &candidates);
                 }
             }
         }
 
-        // TODO: async decode was just added to the c++ api. We should start the
-        // decode here and lazily get the logits as we need them.
+        let max_stop_len = options
+            .stop_sequences
+            .iter()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
+
+        let inner = CandidatePredictor::new(engine, tokens, options.n);
         Self {
-            tokens,
-            text: String::new(),
-            engine,
-            batch,
-            rng: xorshift::Xoroshiro128::from_seed(&seed),
-            candidates,
+            rng: Xoroshiro128::from_seed(&seed),
             ngram_stats,
             options,
-            n_cur,
-            n_decode: 0,
+            text: String::new(),
+            max_stop_len,
             mu: None,
+            inner,
         }
-    }
-
-    /// Get the [`PredictOptions`] for this predictor. This will include any
-    /// seed that was generated if the seed was not provided.
-    pub fn options(&self) -> &PredictOptions {
-        &self.options
     }
 }
 
-impl<'a, 'b> Iterator for Predictor<'a, 'b> {
-    type Item = Predicted;
+impl Into<Vec<llama_token>> for TokenPredictor<'_> {
+    fn into(self) -> Vec<llama_token> {
+        self.inner.into()
+    }
+}
+
+impl<'engine> Iterator for TokenPredictor<'engine> {
+    type Item = llama_token;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.n_decode == self.options.n.get()
-            || self.n_cur >= self.engine.n_ctx() as usize
-        {
-            return None;
-        }
+        let decoded_tokens =
+            &self.inner.tokens[self.inner.tokens.len() - self.inner.n_decode..];
 
-        let decoded_tokens = &self.tokens[self.tokens.len() - self.n_decode..];
         for sequence in self.options.stop_sequences.iter() {
             if decoded_tokens.ends_with(sequence) {
                 return None;
             }
         }
+        // Beginning of the end to check for stop strings. We don't want to
+        // check the entire text because context lengths are getting long and
+        // users might use many stop strings.
+        let end = self.inner.tokens.len().saturating_sub(
+            self.max_stop_len + self.inner.engine.vocab.max_token_len(),
+        );
         for s in self.options.stop_strings.iter() {
-            if self.text.ends_with(s) {
+            if self.text[end..].contains(s) {
                 return None;
             }
         }
@@ -302,100 +391,226 @@ impl<'a, 'b> Iterator for Predictor<'a, 'b> {
             }
         }
 
-        let batch = &mut self.batch;
+        let candidates = self.inner.next()?;
 
-        // Decode the next token
-        self.engine.decode(batch).unwrap();
-
-        // Get the logits for the next token
-        let logits = self.engine.logits(batch.len() - 1);
-
-        // Update the candidates
-        self.candidates
-            .data
-            .iter_mut()
-            .enumerate()
-            .zip(logits.iter())
-            .for_each(|((i, token), &logit)| {
-                token.id = i as llama_token;
-                token.logit = logit;
-                token.p = 0.0;
-            });
-
-        // Sample the next token
-        let next_token = self
-            .candidates
+        let next_token = candidates
             .sample_token(
-                self.tokens,
-                &self.engine.vocab,
+                &self.inner.tokens,
+                &self.inner.engine.vocab,
                 &self.options.sample_options,
                 &mut self.ngram_stats,
                 &mut self.rng,
                 &mut self.mu,
             )
-            .ok()?;
-
-        self.tokens.push(next_token);
-
-        self.batch.clear();
-        self.batch
-            .add_token(next_token, self.n_cur, None, true)
             .unwrap();
 
-        self.n_cur += 1;
-        self.n_decode += 1;
-
-        let piece = self.engine.model.token_to_piece(next_token);
-
+        let piece = self.inner.engine.model.token_to_piece(next_token);
         self.text.push_str(&piece);
 
-        Some(Predicted {
-            token: next_token,
-            piece,
-        })
+        self.inner.record_choice(next_token).ok()?;
+
+        Some(next_token)
+    }
+}
+
+/// A predictor that predicts pieces of text.
+///
+/// If the predictor stops predicting because of a stop sequence, the text will
+/// be truncated at the stop sequence.
+pub struct PiecePredictor<'engine> {
+    inner: TokenPredictor<'engine>,
+}
+
+impl<'engine> PiecePredictor<'engine> {
+    pub fn new(
+        engine: &'engine mut Engine,
+        tokens: Vec<llama_token>,
+        options: PredictOptions,
+    ) -> Self {
+        let token_predictor = TokenPredictor::new(engine, tokens, options);
+
+        Self {
+            inner: token_predictor,
+        }
+    }
+
+    /// Convert into the tokens and text that have been predicted so far.
+    pub fn into_tokens_and_text(self) -> (Vec<llama_token>, String) {
+        let token_predictor = self.inner;
+        (token_predictor.inner.tokens, token_predictor.text)
+    }
+
+    /// Convert into the text that has been predicted so far.
+    pub fn into_text(self) -> String {
+        self.inner.text
+    }
+
+    /// Predict and collect all the pieces, truncating at stop sequences.
+    pub fn collect_text(mut self) -> String {
+        while let Some(_) = self.next() {}
+        self.into_text()
+    }
+
+    /// Predict and collect the tokens and text, truncating at stop sequences.
+    pub fn collect_tokens_and_text(mut self) -> (Vec<llama_token>, String) {
+        while let Some(_) = self.next() {}
+        self.into_tokens_and_text()
+    }
+
+    /// Predict and collect pieces, tokens, and text, truncating at stop
+    /// sequences.
+    pub fn collect_pieces_tokens_text(
+        mut self,
+    ) -> (Vec<String>, Vec<llama_token>, String) {
+        let mut pieces = Vec::new();
+        // We can't collect because it consumes the predictor.
+        while let Some(piece) = self.next() {
+            pieces.push(piece);
+        }
+        let (tokens, text) = self.into_tokens_and_text();
+        (pieces, tokens, text)
+    }
+}
+
+impl<'engine> Iterator for PiecePredictor<'engine> {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let token = match self.inner.next() {
+            Some(token) => token,
+            None => {
+                // We have to check the text for stop strings and truncate the
+                // text if we find one. This matters in cases where a user is
+                // using a while let loop and might convert the predictor into a
+                // string at the end of the loop. If we don't truncate the text,
+                // anything that follows the stop string will be included in the
+                // text.
+                let end = self.inner.inner.tokens.len().saturating_sub(
+                    self.inner.max_stop_len
+                        + self.inner.inner.engine.vocab.max_token_len(),
+                );
+
+                for s in self.inner.options.stop_strings.iter() {
+                    if let Some(idx) = self.inner.text[end..].find(s) {
+                        self.inner.text.truncate(
+                            (end + idx + s.len()).min(self.inner.text.len()),
+                        );
+                        return None;
+                    }
+                }
+
+                return None;
+            }
+        };
+        let piece = self.inner.inner.engine.model.token_to_piece(token);
+        Some(piece)
+    }
+}
+
+impl<'engine> Into<String> for PiecePredictor<'engine> {
+    fn into(self) -> String {
+        self.into_text()
+    }
+}
+impl<'engine> Into<Vec<llama_token>> for PiecePredictor<'engine> {
+    fn into(self) -> Vec<llama_token> {
+        self.inner.inner.tokens
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use llama_cpp_sys_3::llama_token;
+
     use crate::{Engine, PredictOptions};
-    use std::path::PathBuf;
+    use std::{num::NonZeroUsize, path::PathBuf};
+
+    const PROMPT: &str = "The quick brown fox jumps over the lazy dog.";
 
     #[test]
     #[ignore = "long running"]
     /// Test prediction with greedy sampling and a well-known sequence.
-    fn predict_greedy() {
-        const PROMPT: &str = "The quick brown fox jumps over the lazy dog.";
-
+    fn test_token_predictor() {
         let mut engine = Engine::from_path(
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("models/model.gguf"),
         )
         .unwrap();
 
         let tokenized = engine.model.tokenize(PROMPT, false);
-        let mut actual = tokenized[..5].to_vec();
-        let expected_completion = tokenized[5..].to_vec();
+        let prefix = tokenized[..5].to_vec();
+        let expected = tokenized[5..].to_vec();
 
-        let opts = PredictOptions::default()
-            .add_model_eos(&engine.model)
-            // Stop at period.
-            .add_stop_sequence(vec![29889]);
+        let mut opts = PredictOptions::default().add_stop(".".to_owned());
+        opts.n = NonZeroUsize::new(2 + expected.len()).unwrap();
 
-        dbg!(&opts);
+        let actual: Vec<llama_token> =
+            engine.predict_tokens(prefix, opts).collect();
 
-        let mut predictor = engine.predict(&mut actual, opts);
+        assert_eq!(actual, expected);
+    }
 
-        assert_eq!(predictor.next().unwrap().piece, " j");
-        assert_eq!(predictor.next().unwrap().piece, "umps");
-        assert_eq!(predictor.next().unwrap().piece, " over");
-        assert_eq!(predictor.next().unwrap().piece, " the");
-        assert_eq!(predictor.next().unwrap().piece, " lazy");
-        assert_eq!(predictor.next().unwrap().piece, " dog");
-        let last = predictor.next().unwrap();
-        assert_eq!(&last.token, &29889);
-        assert_eq!(&last.piece, ".");
-        assert_eq!(predictor.next(), None);
+    #[test]
+    // #[ignore = "long running"]
+    /// Test candidate prediction with greedy sampling and a well-known sequence.
+    #[ignore = "long running"]
+    fn test_candidate_predictor() {
+        let mut engine = Engine::from_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("models/model.gguf"),
+        )
+        .unwrap();
 
-        assert_eq!(actual[5..], expected_completion);
+        let tokenized = engine.model.tokenize(PROMPT, false);
+        let prefix = tokenized[..5].to_vec();
+        let expected_completion = &tokenized[5..];
+
+        let mut predictor =
+            engine.predict_candidates(prefix, 6.try_into().unwrap());
+
+        // We can't use a for loop here because we need to record the choice in
+        // the predictor, and a for loop *consumes* the `predictor`, so to use
+        // the candidate predictor we need to use a while let loop (because
+        // ownership issues). For an example of how to use it in a wrapper to
+        // make your use more ergonomic, see the TokenPredictor struct.
+        while let Some(candidates) = predictor.next() {
+            let token = candidates.sample_token_greedy();
+
+            // This must be called or iteration will end.
+            if predictor.record_choice(token.id).is_err() {
+                break;
+            }
+
+            // This is for the test only. In a real application, you would
+            // probably want to use the PredictOptions to stop the prediction.
+            if predictor.n_decode == expected_completion.len() {
+                break;
+            }
+        }
+
+        assert_eq!(predictor.tokens, tokenized);
+    }
+
+    #[test]
+    // #[ignore = "long running"]
+    /// Test candidate prediction with greedy sampling and a well-known sequence.
+    #[ignore = "long running"]
+    fn test_piece_predictor() {
+        let mut engine = Engine::from_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("models/model.gguf"),
+        )
+        .unwrap();
+
+        let tokenized = engine.model.tokenize(PROMPT, false);
+        let prefix = tokenized[..5].to_vec();
+        let expected: Vec<String> = tokenized[5..]
+            .iter()
+            .map(|&t| engine.model.token_to_piece(t))
+            .collect();
+
+        let mut opts = PredictOptions::default().add_stop(".".to_owned());
+        opts.n = NonZeroUsize::new(2 + expected.len()).unwrap();
+
+        let actual: Vec<String> = engine.predict_pieces(prefix, opts).collect();
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/probability.rs
+++ b/src/probability.rs
@@ -16,7 +16,7 @@ where
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Hash)]
 #[repr(transparent)]
 pub struct Probability<F> {
-    p: F,
+    pub(crate) p: F,
 }
 impl<F> Probability<F> {
     pub fn from_f(p: F) -> Result<Self, InvalidProbability<F>>

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -60,6 +60,18 @@ impl Prompt {
     /// Format the prompt for a specific model. This adds a BOS token if the
     /// model requires it. If this is unknown, a BOS token will not be added.
     /// This is the recommended method for formatting a prompt.
+    ///
+    /// This will first attempt to use native formatting for the model. If a
+    /// format would be unknown, it will attempt to apply a chat template using
+    /// the model's metadata and `llama.cpp`. If *that* fails, it will use the
+    /// [`Format::Unknown`] format.
+    ///
+    /// This does not add the assistant's prefix to the prompt. If this is
+    /// desired, [`format_agent_prefix`] should be called after this method or
+    /// [`Model::apply_chat_template`] should be used instead with the `add_ass`
+    /// parameter set to `true`.
+    /// 
+    /// [`format_agent_prefix`]: Self::format_agent_prefix
     pub fn format_for_model<F>(
         &self,
         model: &Model,
@@ -68,7 +80,13 @@ impl Prompt {
     where
         F: std::fmt::Write,
     {
-        let format = Format::from_model(model).unwrap_or(Format::Unknown);
+        let format = match Format::from_model(model) {
+            Some(format) => format,
+            None => match model.apply_chat_template(None, self, false) {
+                Some(string) => return f.write_str(&string),
+                None => Format::Unknown,
+            },
+        };
         format.format_prompt(self, Some(model), f)
     }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -68,7 +68,7 @@ impl Prompt {
     where
         F: std::fmt::Write,
     {
-        let format = Format::from_model(model);
+        let format = Format::from_model(model).unwrap_or(Format::Unknown);
         format.format_prompt(self, Some(model), f)
     }
 

--- a/src/prompt/format.rs
+++ b/src/prompt/format.rs
@@ -154,7 +154,7 @@ impl Format {
                         llama3::EOT
                     )?;
                 }
-                // Logic is borrowed fro:
+                // Logic is borrowed from:
                 // https://github.com/meta-llama/llama/blob/main/llama/generation.py
                 Format::LLaMA2Chat => {
                     assert!(


### PR DESCRIPTION
* Candidate iterator. Yields candidates for maximum control over
  sampling.
* Token iterator. Yields tokens only.
* Piece iterator. Yields string pieces only.
* This also fixes a bug where a bad regex for VocabType::Safe was
  breaking stop criteria. It is not guaranteed to be perfect now, but
  it will at least allow stopping at ".", "!", etc.
* Fixes various bugs in sampling code.
* Fix documentation in `sample.rs` and `candidates.rs` among others.
* Fix mirostat parameters, since mu should always be init to 2 * tau.
* Safe API for `llama_chat_template`