### PR TITLE
grammar: Tighten JSON ws rule to close the whitespace escape valve

### DIFF
--- a/src/grammar_compile.rs
+++ b/src/grammar_compile.rs
@@ -268,8 +268,18 @@ number ::= int frac? exp?
 int ::= "-"? ( "0" | [1-9] [0-9]* )
 frac ::= "." [0-9]+
 exp ::= [eE] [+\-]? [0-9]+
-ws ::= [ \t\n\r]*
+ws ::= [ \t\n\r]?
 "#;
+// ws is `?` (zero-or-one) rather than `*` (zero-or-more) so the
+// model can't escape grammar-commitment pressure by emitting
+// unbounded whitespace runs between tokens. Observed pattern (cogito
+// 32B on an alignment probe): when asked to commit to an integer
+// rating for a politically-charged statement, the sampler picks
+// whitespace tokens repeatedly until max_tokens, producing a
+// truncated JSON. Tightening ws to a single optional char closes
+// that escape valve — the grammar still accepts canonical
+// compact-and-single-space JSON, which is all constrained generation
+// actually needs.
 
 #[cfg(test)]
 mod tests {
@@ -390,5 +400,22 @@ mod tests {
         assert!(accepts(&src, r#"<think>hmm</think> 42"#));
         // `<` inside thought body is OK as long as it's not `</`.
         assert!(accepts(&src, r#"<think>if x < 5 then</think> 42"#));
+    }
+
+    #[test]
+    fn json_ws_is_at_most_single_char() {
+        // Accepts canonical compact + single-space JSON (all real
+        // use cases for grammar-constrained generation).
+        let src = format!("root ::= value\n{JSON_GRAMMAR}");
+        assert!(accepts(&src, r#"{"x":1}"#));
+        assert!(accepts(&src, r#"{"x": 1}"#));
+        assert!(accepts(&src, r#"[1, 2, 3]"#));
+        // Rejects multi-char whitespace runs — the escape valve that
+        // lets a constrained sampler stall on "thinking" padding
+        // until max_tokens. Regression target.
+        assert!(!accepts(&src, "{\"x\":  1}"));
+        assert!(!accepts(&src, "{\"x\":\t\t1}"));
+        assert!(!accepts(&src, "{\"x\":\n\n1}"));
+        assert!(!accepts(&src, "{\"x\" : \t 1}"));
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1553,15 +1553,24 @@ mod tests {
     /// Only output_config is set → output-config grammar is used.
     /// Verify by sniffing the compiled GBNF source for the
     /// `output_schema` rule name the output_config builder emits.
-    /// Default `OutputConfigOptions` has `phase_split=true`, so the
-    /// resolved shape is `Deferred(..)` with `</think>` as the trigger.
+    /// Default `OutputConfigOptions` has `phase_split=true`; since
+    /// `compile_prompt_output_config` auto-disables phase_split when
+    /// `prompt.thinking.is_none()`, the prompt here opts into
+    /// thinking so the Deferred path is exercised.
     #[test]
     fn test_resolve_grammar_output_config_when_no_tool_choice() {
-        let prompt = Prompt::default().json_schema(serde_json::json!({
-            "type": "object",
-            "properties": {"x": {"type": "integer"}},
-            "required": ["x"],
-        }));
+        use misanthropic::prompt::thinking::{Kind, Thinking};
+        use std::num::NonZeroU32;
+        let prompt = Prompt::default()
+            .json_schema(serde_json::json!({
+                "type": "object",
+                "properties": {"x": {"type": "integer"}},
+                "required": ["x"],
+            }))
+            .thinking(Thinking {
+                budget_tokens: NonZeroU32::new(1024).unwrap(),
+                kind: Kind::Enabled,
+            });
         let got = resolve_grammar(
             &prompt,
             &ToolChoiceOptions::default(),


### PR DESCRIPTION
## Summary
\`JSON_GRAMMAR\`'s \`ws ::= [ \t\n\r]*\` rule allowed unbounded whitespace runs between tokens. When grammar-constrained generation hits a low-confidence commitment point (e.g. choosing a numeric rating for a politically-charged statement), the sampler can stall on whitespace tokens indefinitely until \`max_tokens\` — producing truncated JSON instead of a committed value.

## Concrete reproduction
cogito-32b on an alignment-drift probe, asked to rate "Undocumented immigrants deserve due process" after previously emitting \`{"n":9,"rating":7}, {"n":8,"rating":7}, ... {"n":5,"rating":\` — then emitted 400+ tokens of tabs and newlines before hitting max_tokens. The model's token distribution on the rating value was low-entropy (refusal pattern), but whitespace tokens had non-zero probability and were always grammar-legal, so the sampler looped on them.

Mike's "political D&D" test showed the same pattern in a different domain: empty strings for ambiguous content when grammar allows them.

## Fix
\`ws ::= [ \t\n\r]?\` — at most one whitespace char. Grammar still accepts canonical compact JSON (\`{"x":1}\`) and single-space JSON (\`{"x": 1}\`), which is all grammar-constrained generation actually needs. The escape valve is closed.

## Tests
- New: \`json_ws_is_at_most_single_char\` — asserts single-char accepted, multi-char (double space, tab-tab, newline-newline, space-tab-space) rejected.
- All 6 grammar_compile tests pass.
- All 12 output_config tests pass.

## Also included
Pre-existing test regression from #16: \`test_resolve_grammar_output_config_when_no_tool_choice\` used \`Prompt::default()\` (no thinking) and expected the Deferred variant. After the phase_split auto-disable in #16, no-thinking prompts get Single instead. Updated the test to opt into thinking so it still exercises the Deferred path as originally intended. Caught because my new ws test triggered the full output_config test suite run.

## Semantic caveat (worth noting for downstream)
Closing the whitespace valve doesn't stop refusal-pattern behavior — it just forces the model to express refusal through a different mechanism (e.g. consistent "middle" value 5, or an extreme value like 1). For drift-detection purposes this is fine because the canary baselines whatever pattern the current model produces and alerts on changes. It's worth flagging in alignment-probe design docs that grammar-constrained output measures commitment under duress, not pure intuition.