### PR TITLE
session: Debug log + inspect_prompt example for auto-tip diagnostics

### DIFF
--- a/examples/inspect_prompt.rs
+++ b/examples/inspect_prompt.rs
@@ -1,0 +1,151 @@
+//! Inspect a saved misanthropic `Prompt` JSON: render via the chat
+//! template, tokenize with breakpoints, and print enough structure to
+//! attribute prefix-cache mismatches (re-tokenization shifts at
+//! assistant-content boundaries, breakpoint placement, etc.).
+//!
+//! Usage:
+//!   cargo run --example inspect_prompt --features cli -- \
+//!     <path-to-prompt.json>
+//!
+//! The model path defaults to `models/model.gguf` (the same symlink
+//! `dump_template` and the integration tests use). Override via the
+//! `DRAMA_LLAMA_MODEL` env var if needed.
+//!
+//! Output highlights for cache debugging:
+//! - Total tokens + breakpoint positions (cache_control markers).
+//! - For each assistant message: the token position range and the
+//!   first/last 5 tokens (decoded as pieces) — useful for spotting
+//!   thought-stripping or JSON re-serialization between calls when
+//!   comparing two consecutive prompt logs.
+//! - The `add_generation_prompt=true` render's tail tokens (what the
+//!   model would see queued up before its first generated token).
+
+use std::path::PathBuf;
+
+use drama_llama::{
+    chat_template::{ChatTemplate, RenderOptions, tokenize_with_breakpoints},
+    LlamaCppModel, Token,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let prompt_path: PathBuf = std::env::args()
+        .nth(1)
+        .ok_or("usage: inspect_prompt <prompt.json>")?
+        .into();
+    let model_path: PathBuf = std::env::var_os("DRAMA_LLAMA_MODEL")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("models/model.gguf")
+        });
+
+    let json = std::fs::read_to_string(&prompt_path)?;
+    let prompt: misanthropic::Prompt = serde_json::from_str(&json)?;
+    let model = LlamaCppModel::from_file(model_path.clone(), None)
+        .ok_or_else(|| format!("could not load model: {}", model_path.display()))?;
+    let tmpl = ChatTemplate::from_model(&model)?;
+
+    println!("=== prompt: {} ===", prompt_path.display());
+    println!("model         : {}", prompt.model);
+    println!("messages      : {}", prompt.messages.len());
+    println!(
+        "tool_choice   : {:?}",
+        prompt.tool_choice.as_ref().map(|c| format!("{c:?}"))
+    );
+    println!("output_config : {}", prompt.output_config.is_some());
+    println!();
+
+    let opts = RenderOptions::default().with_generation_prompt(true);
+    let rendered = tmpl.render_with_breakpoints(&prompt, &opts)?;
+    let (tokens, breakpoints) = tokenize_with_breakpoints(&model, &rendered);
+
+    println!("=== full render ===");
+    println!("rendered bytes : {}", rendered.text.len());
+    println!("total tokens   : {}", tokens.len());
+    println!("breakpoints    : {:?}", breakpoints);
+    println!();
+
+    // Per-message render inspection: render successive partials
+    // (system, system+msg0, system+msg0+msg1, ...) and use their
+    // tokenized lengths to attribute each message's token range.
+    println!("=== per-message token ranges ===");
+    let mut cursor = 0usize;
+    for (i, msg) in prompt.messages.iter().enumerate() {
+        // Render up to and including this message via render_with on a
+        // truncated prompt clone (cheap: minijinja's hot path).
+        let mut partial = prompt.clone();
+        partial.messages.truncate(i + 1);
+        // No assistant header on partial renders; we want the close of
+        // each message, not "ready for next".
+        let partial_opts =
+            RenderOptions::default().with_generation_prompt(false);
+        let partial_text = tmpl.render_with(&partial, &partial_opts)?;
+        let partial_tokens = model.tokenize(&partial_text, true);
+        let end = partial_tokens.len();
+        let role = msg.role.as_str();
+        let preview = match peek_first_text(&msg.content) {
+            Some(s) => {
+                let trimmed: String =
+                    s.chars().take(60).collect::<String>().replace('\n', "⏎");
+                format!("{trimmed}…")
+            }
+            None => "<no text block>".to_string(),
+        };
+        println!(
+            "  msg {i:2} {role:9} tokens [{cursor:5}..{end:5}) ({} tok) {preview}",
+            end - cursor,
+        );
+        if role == "assistant" {
+            // For asst messages: print first 5 + last 5 token ids of the
+            // message body. Useful for diff'ing the same message across
+            // two consecutive prompt logs to spot re-render shifts.
+            let slice = &tokens[cursor..end.min(tokens.len())];
+            let head = slice.iter().take(5).copied().collect::<Vec<Token>>();
+            let tail = slice
+                .iter()
+                .rev()
+                .take(5)
+                .rev()
+                .copied()
+                .collect::<Vec<Token>>();
+            let head_p: Vec<String> =
+                head.iter().map(|&t| model.token_to_piece(t)).collect();
+            let tail_p: Vec<String> =
+                tail.iter().map(|&t| model.token_to_piece(t)).collect();
+            println!(
+                "                head 5: {head:?} = {head_p:?}\n                tail 5: {tail:?} = {tail_p:?}"
+            );
+        }
+        cursor = end;
+    }
+    println!();
+
+    // Tail of the full render with add_generation_prompt=true: shows
+    // the assistant header the model is queued up to continue from.
+    let tail_n = 12usize;
+    let tail_start = tokens.len().saturating_sub(tail_n);
+    let tail_pieces: Vec<String> = tokens[tail_start..]
+        .iter()
+        .map(|&t| model.token_to_piece(t))
+        .collect();
+    println!("=== last {tail_n} tokens (with generation_prompt=true) ===");
+    println!("ids    : {:?}", &tokens[tail_start..]);
+    println!("pieces : {:?}", tail_pieces);
+
+    Ok(())
+}
+
+fn peek_first_text(content: &misanthropic::prompt::message::Content) -> Option<String> {
+    use misanthropic::prompt::message::{Block, Content};
+    match content {
+        Content::SinglePart(s) => Some(s.to_string()),
+        Content::MultiPart(blocks) => {
+            for b in blocks {
+                if let Block::Text { text, .. } = b {
+                    return Some(text.to_string());
+                }
+            }
+            None
+        }
+    }
+}

--- a/src/chat_template.rs
+++ b/src/chat_template.rs
@@ -532,11 +532,14 @@ fn render_partial(
 /// special-token IDs — the same convention [`Session::prepare_call`]
 /// uses.
 ///
-/// Phase 3 (Session integration) will wire this in; external callers
-/// don't need it yet, hence `pub(crate)`.
+/// Used internally by [`Session::prepare_call_cached`] for the
+/// prefix-cache lookup, and exposed publicly so callers can build
+/// inspection / diagnostic tools that reproduce exactly the same
+/// tokenization the cache machinery sees (see
+/// `examples/inspect_prompt.rs`).
 ///
 /// [`Session::prepare_call`]: crate::Session
-pub(crate) fn tokenize_with_breakpoints<M: Model>(
+pub fn tokenize_with_breakpoints<M: Model>(
     model: &M,
     rendered: &RenderedWithBreakpoints,
 ) -> (Vec<Token>, Vec<usize>) {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -966,12 +966,57 @@ impl<B: Backend> Session<B> {
         new_breakpoints: &[usize],
     ) -> Result<(Vec<Token>, usize, usize), SessionError> {
         let l_hit_raw = match self.prefix_cache.as_ref() {
-            Some(cache) if !cache.prev_tokens.is_empty() => compute_l_hit(
-                &cache.prev_tokens,
-                new_tokens,
-                new_breakpoints,
-                cache.internal_tip,
-            ),
+            Some(cache) if !cache.prev_tokens.is_empty() => {
+                let picked = compute_l_hit(
+                    &cache.prev_tokens,
+                    new_tokens,
+                    new_breakpoints,
+                    cache.internal_tip,
+                );
+                // Diagnostic: when the auto-tip is set but didn't win,
+                // log enough state to attribute the loss. The case worth
+                // attention is `tip > safe` — the LCP cut off shorter
+                // than `prev_tokens` length, almost always a BPE
+                // re-tokenization mismatch in the assistant content.
+                // `prev_at_lcp` and `new_at_lcp` point at the first
+                // divergent token; comparing them tells us whether it's
+                // a single-token shift or a wholesale re-render
+                // (thoughts stripped, JSON re-serialized, etc.).
+                #[cfg(feature = "axum")]
+                if let Some(tip) = cache.internal_tip {
+                    let lcp = longest_common_prefix_len(
+                        &cache.prev_tokens,
+                        new_tokens,
+                    );
+                    let safe = lcp.saturating_sub(1);
+                    if tip > safe && tip > picked {
+                        let prev_len = cache.prev_tokens.len();
+                        let new_len = new_tokens.len();
+                        let prev_at_lcp = cache
+                            .prev_tokens
+                            .get(lcp)
+                            .copied()
+                            .unwrap_or(-1);
+                        let new_at_lcp = new_tokens
+                            .get(lcp)
+                            .copied()
+                            .unwrap_or(-1);
+                        tracing::debug!(
+                            tip,
+                            lcp,
+                            safe,
+                            picked,
+                            prev_len,
+                            new_len,
+                            prev_at_lcp,
+                            new_at_lcp,
+                            "auto-tip ineligible: tip past safe (LCP shorter than expected — \
+                             likely re-tokenization mismatch in asst content)",
+                        );
+                    }
+                }
+                picked
+            }
             _ => 0,
         };
 


### PR DESCRIPTION
Follow-up to #19. The 2026-05-05 verification smoke confirmed the auto-tip works for the big phase transitions (Reflect/Survey hit `cache_read ≈ input - 30 tokens` at 22k+ input — design payoff) and ~70% of think_act calls. The remaining ~30% miss back to the intro user breakpoint. Hypothesis: BPE re-tokenization mismatch in assistant content (chat-template whitespace, thought-block re-rendering, parsed-then-reserialized tool_call JSON, etc.).

Two diagnostics to attribute:

1. **`compute_l_hit` debug log when tip is ineligible.** Emits `tip/lcp/safe/picked/prev_len/new_len/prev_at_lcp/new_at_lcp` when the auto-tip is set but loses to the user-breakpoint path because LCP cut off shorter than `prev_tokens.len()`. Gated on `cfg(feature = "axum")` to match the existing `tracing::debug!` convention. Fires only when `tip > safe AND tip > picked`.

2. **`examples/inspect_prompt.rs`** — loads a saved misanthropic Prompt JSON (e.g. `agents/logs/prompts/.../prompt.json`), renders via `ChatTemplate`, tokenizes with breakpoints, and prints per-message token ranges plus head/tail token IDs+pieces for each assistant message. Diff'ing two consecutive prompt logs will pinpoint exactly where re-rendering shifts the tokenization.

Required a small API surface change: promoted `tokenize_with_breakpoints` from `pub(crate)` to `pub` so external inspection tools can reproduce the cache machinery's exact tokenization.

Smoke also surfaced an unrelated grammar gap — Cogito emitted `"can\u27t"` (invalid 3-hex-digit unicode escape) and the JSON grammar accepted it, causing a parse failure and a "model didn't produce tool calls" nudge. Filing that separately as a JSON-grammar tightening; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)