### PR TITLE
session: Hash-keyed prefix-reuse via SHA-256 of partial chat-template renders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ xorshift = "0.1"
 rayon = "1.10.0"
 dashmap = "6"
 rustc-hash = "2"
+sha2 = "0.10"
 minijinja = { version = "2.5", features = ["loader", "json"] }
 minijinja-contrib = { version = "2.5", features = ["pycompat"] }
 misanthropic = { git = "https://github.com/mdegans/misanthropic.git", branch = "dev", default-features = false, features = [

--- a/examples/inspect_prompt.rs
+++ b/examples/inspect_prompt.rs
@@ -1,0 +1,151 @@
+//! Inspect a saved misanthropic `Prompt` JSON: render via the chat
+//! template, tokenize with breakpoints, and print enough structure to
+//! attribute prefix-cache mismatches (re-tokenization shifts at
+//! assistant-content boundaries, breakpoint placement, etc.).
+//!
+//! Usage:
+//!   cargo run --example inspect_prompt --features cli -- \
+//!     <path-to-prompt.json>
+//!
+//! The model path defaults to `models/model.gguf` (the same symlink
+//! `dump_template` and the integration tests use). Override via the
+//! `DRAMA_LLAMA_MODEL` env var if needed.
+//!
+//! Output highlights for cache debugging:
+//! - Total tokens + breakpoint positions (cache_control markers).
+//! - For each assistant message: the token position range and the
+//!   first/last 5 tokens (decoded as pieces) — useful for spotting
+//!   thought-stripping or JSON re-serialization between calls when
+//!   comparing two consecutive prompt logs.
+//! - The `add_generation_prompt=true` render's tail tokens (what the
+//!   model would see queued up before its first generated token).
+
+use std::path::PathBuf;
+
+use drama_llama::{
+    chat_template::{ChatTemplate, RenderOptions, tokenize_with_breakpoints},
+    LlamaCppModel, Token,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let prompt_path: PathBuf = std::env::args()
+        .nth(1)
+        .ok_or("usage: inspect_prompt <prompt.json>")?
+        .into();
+    let model_path: PathBuf = std::env::var_os("DRAMA_LLAMA_MODEL")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("models/model.gguf")
+        });
+
+    let json = std::fs::read_to_string(&prompt_path)?;
+    let prompt: misanthropic::Prompt = serde_json::from_str(&json)?;
+    let model = LlamaCppModel::from_file(model_path.clone(), None)
+        .ok_or_else(|| format!("could not load model: {}", model_path.display()))?;
+    let tmpl = ChatTemplate::from_model(&model)?;
+
+    println!("=== prompt: {} ===", prompt_path.display());
+    println!("model         : {}", prompt.model);
+    println!("messages      : {}", prompt.messages.len());
+    println!(
+        "tool_choice   : {:?}",
+        prompt.tool_choice.as_ref().map(|c| format!("{c:?}"))
+    );
+    println!("output_config : {}", prompt.output_config.is_some());
+    println!();
+
+    let opts = RenderOptions::default().with_generation_prompt(true);
+    let rendered = tmpl.render_with_breakpoints(&prompt, &opts)?;
+    let (tokens, breakpoints) = tokenize_with_breakpoints(&model, &rendered);
+
+    println!("=== full render ===");
+    println!("rendered bytes : {}", rendered.text.len());
+    println!("total tokens   : {}", tokens.len());
+    println!("breakpoints    : {:?}", breakpoints);
+    println!();
+
+    // Per-message render inspection: render successive partials
+    // (system, system+msg0, system+msg0+msg1, ...) and use their
+    // tokenized lengths to attribute each message's token range.
+    println!("=== per-message token ranges ===");
+    let mut cursor = 0usize;
+    for (i, msg) in prompt.messages.iter().enumerate() {
+        // Render up to and including this message via render_with on a
+        // truncated prompt clone (cheap: minijinja's hot path).
+        let mut partial = prompt.clone();
+        partial.messages.truncate(i + 1);
+        // No assistant header on partial renders; we want the close of
+        // each message, not "ready for next".
+        let partial_opts =
+            RenderOptions::default().with_generation_prompt(false);
+        let partial_text = tmpl.render_with(&partial, &partial_opts)?;
+        let partial_tokens = model.tokenize(&partial_text, true);
+        let end = partial_tokens.len();
+        let role = msg.role.as_str();
+        let preview = match peek_first_text(&msg.content) {
+            Some(s) => {
+                let trimmed: String =
+                    s.chars().take(60).collect::<String>().replace('\n', "⏎");
+                format!("{trimmed}…")
+            }
+            None => "<no text block>".to_string(),
+        };
+        println!(
+            "  msg {i:2} {role:9} tokens [{cursor:5}..{end:5}) ({} tok) {preview}",
+            end - cursor,
+        );
+        if role == "assistant" {
+            // For asst messages: print first 5 + last 5 token ids of the
+            // message body. Useful for diff'ing the same message across
+            // two consecutive prompt logs to spot re-render shifts.
+            let slice = &tokens[cursor..end.min(tokens.len())];
+            let head = slice.iter().take(5).copied().collect::<Vec<Token>>();
+            let tail = slice
+                .iter()
+                .rev()
+                .take(5)
+                .rev()
+                .copied()
+                .collect::<Vec<Token>>();
+            let head_p: Vec<String> =
+                head.iter().map(|&t| model.token_to_piece(t)).collect();
+            let tail_p: Vec<String> =
+                tail.iter().map(|&t| model.token_to_piece(t)).collect();
+            println!(
+                "                head 5: {head:?} = {head_p:?}\n                tail 5: {tail:?} = {tail_p:?}"
+            );
+        }
+        cursor = end;
+    }
+    println!();
+
+    // Tail of the full render with add_generation_prompt=true: shows
+    // the assistant header the model is queued up to continue from.
+    let tail_n = 12usize;
+    let tail_start = tokens.len().saturating_sub(tail_n);
+    let tail_pieces: Vec<String> = tokens[tail_start..]
+        .iter()
+        .map(|&t| model.token_to_piece(t))
+        .collect();
+    println!("=== last {tail_n} tokens (with generation_prompt=true) ===");
+    println!("ids    : {:?}", &tokens[tail_start..]);
+    println!("pieces : {:?}", tail_pieces);
+
+    Ok(())
+}
+
+fn peek_first_text(content: &misanthropic::prompt::message::Content) -> Option<String> {
+    use misanthropic::prompt::message::{Block, Content};
+    match content {
+        Content::SinglePart(s) => Some(s.to_string()),
+        Content::MultiPart(blocks) => {
+            for b in blocks {
+                if let Block::Text { text, .. } = b {
+                    return Some(text.to_string());
+                }
+            }
+            None
+        }
+    }
+}

--- a/src/chat_template.rs
+++ b/src/chat_template.rs
@@ -532,11 +532,14 @@ fn render_partial(
 /// special-token IDs — the same convention [`Session::prepare_call`]
 /// uses.
 ///
-/// Phase 3 (Session integration) will wire this in; external callers
-/// don't need it yet, hence `pub(crate)`.
+/// Used internally by [`Session::prepare_call_cached`] for the
+/// prefix-cache lookup, and exposed publicly so callers can build
+/// inspection / diagnostic tools that reproduce exactly the same
+/// tokenization the cache machinery sees (see
+/// `examples/inspect_prompt.rs`).
 ///
 /// [`Session::prepare_call`]: crate::Session
-pub(crate) fn tokenize_with_breakpoints<M: Model>(
+pub fn tokenize_with_breakpoints<M: Model>(
     model: &M,
     rendered: &RenderedWithBreakpoints,
 ) -> (Vec<Token>, Vec<usize>) {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -966,12 +966,57 @@ impl<B: Backend> Session<B> {
         new_breakpoints: &[usize],
     ) -> Result<(Vec<Token>, usize, usize), SessionError> {
         let l_hit_raw = match self.prefix_cache.as_ref() {
-            Some(cache) if !cache.prev_tokens.is_empty() => compute_l_hit(
-                &cache.prev_tokens,
-                new_tokens,
-                new_breakpoints,
-                cache.internal_tip,
-            ),
+            Some(cache) if !cache.prev_tokens.is_empty() => {
+                let picked = compute_l_hit(
+                    &cache.prev_tokens,
+                    new_tokens,
+                    new_breakpoints,
+                    cache.internal_tip,
+                );
+                // Diagnostic: when the auto-tip is set but didn't win,
+                // log enough state to attribute the loss. The case worth
+                // attention is `tip > safe` — the LCP cut off shorter
+                // than `prev_tokens` length, almost always a BPE
+                // re-tokenization mismatch in the assistant content.
+                // `prev_at_lcp` and `new_at_lcp` point at the first
+                // divergent token; comparing them tells us whether it's
+                // a single-token shift or a wholesale re-render
+                // (thoughts stripped, JSON re-serialized, etc.).
+                #[cfg(feature = "axum")]
+                if let Some(tip) = cache.internal_tip {
+                    let lcp = longest_common_prefix_len(
+                        &cache.prev_tokens,
+                        new_tokens,
+                    );
+                    let safe = lcp.saturating_sub(1);
+                    if tip > safe && tip > picked {
+                        let prev_len = cache.prev_tokens.len();
+                        let new_len = new_tokens.len();
+                        let prev_at_lcp = cache
+                            .prev_tokens
+                            .get(lcp)
+                            .copied()
+                            .unwrap_or(-1);
+                        let new_at_lcp = new_tokens
+                            .get(lcp)
+                            .copied()
+                            .unwrap_or(-1);
+                        tracing::debug!(
+                            tip,
+                            lcp,
+                            safe,
+                            picked,
+                            prev_len,
+                            new_len,
+                            prev_at_lcp,
+                            new_at_lcp,
+                            "auto-tip ineligible: tip past safe (LCP shorter than expected — \
+                             likely re-tokenization mismatch in asst content)",
+                        );
+                    }
+                }
+                picked
+            }
             _ => 0,
         };
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -80,7 +80,6 @@ use misanthropic::response::Usage;
 
 use crate::{
     backend::{Backend, Model},
-    chat_template::tokenize_with_breakpoints,
     grammar_for_prompt, output_config, ChatTemplate, ChatTemplateError, Engine,
     OutputConfigError, OutputConfigOptions, PredictOptions, Prompt,
     RenderOptions, RepetitionOptions, SampleOptions, SamplingMode, Token,
@@ -202,6 +201,24 @@ struct PrefixCache {
     /// corrupt the next call's restore. Update both ends together if
     /// you change predictor stop semantics.
     internal_tip: Option<usize>,
+    /// SHA-256 of the canonical chat-template render (i.e. the
+    /// `partial_text`) at each breakpoint, parallel to
+    /// [`Self::prev_breakpoints`] (same indexing). Used by
+    /// [`compute_l_hit`]'s hash-keyed lookup to recognize a prefix
+    /// across calls even when the byte-level rendering would diverge
+    /// (e.g. cogito-style permissive JSON whitespace re-rendered through
+    /// `serde_json::to_string` on `Block::ToolUse.input`). The render
+    /// is independent of `cache_control` markers — those are metadata,
+    /// not rendered content — so hashes stay stable as breakpoints
+    /// move with `cache_windowed`.
+    prev_breakpoint_hashes: Vec<[u8; 32]>,
+    /// SHA-256 of the canonical chat-template render up to the
+    /// auto-tip position (end of just-generated assistant content).
+    /// `None` until the first generation completes. Computed by
+    /// re-rendering the conversation with the parsed assistant block
+    /// appended, taking the partial render at that synthesized
+    /// breakpoint, and hashing.
+    prev_tip_hash: Option<[u8; 32]>,
 }
 
 impl PrefixCache {
@@ -212,6 +229,8 @@ impl PrefixCache {
             prev_breakpoints: Vec::new(),
             last_reused_tokens: 0,
             internal_tip: None,
+            prev_breakpoint_hashes: Vec::new(),
+            prev_tip_hash: None,
         }
     }
 
@@ -221,12 +240,70 @@ impl PrefixCache {
         self.prev_breakpoints.clear();
         self.last_reused_tokens = 0;
         self.internal_tip = None;
+        self.prev_breakpoint_hashes.clear();
+        self.prev_tip_hash = None;
     }
 }
 
 /// Length of the longest prefix shared between `a` and `b`, in tokens.
 fn longest_common_prefix_len(a: &[Token], b: &[Token]) -> usize {
     a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+/// SHA-256 of the canonical chat-template render at a single
+/// breakpoint. Caller passes a `partial_text` from
+/// [`crate::chat_template::RenderedWithBreakpoints`].
+///
+/// Used as the cache key for hash-keyed prefix-reuse on `PrefixCache`:
+/// two calls whose source data agrees up to a given breakpoint produce
+/// identical `partial_text`s (the chat-template render is deterministic
+/// given source and excludes `cache_control` metadata), so the same
+/// hash. The `prev_tokens` stored against this hash come from the
+/// model's original emission and may not be a bytewise-identical
+/// tokenization of the same `partial_text` — a single-token BPE drift
+/// at the JSON-whitespace boundary is acceptable; cogito's permissive
+/// grammar means the model is whitespace-tolerant and the existing
+/// `lcp-1` safety margin in [`compute_l_hit`] handles it.
+fn hash_partial_text(text: &str) -> [u8; 32] {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(text.as_bytes());
+    hasher.finalize().into()
+}
+
+/// Hash-keyed L_hit lookup. Returns the largest cached token position
+/// (over breakpoint hashes paired with `prev_breakpoints`, plus the
+/// auto-tip hash paired with `internal_tip`) whose stored hash also
+/// appears in `new_breakpoint_hashes`. Returns 0 when no hash matches.
+///
+/// `cap` bounds the result — typically `new_tokens.len()` — so we
+/// never claim to reuse more tokens than the new request has.
+///
+/// Pure function; lifted out of `kv_setup_and_chunk_prefill` so its
+/// "longest match wins, capped at new_tokens.len()" contract is
+/// directly testable without an engine.
+fn hash_keyed_l_hit(
+    prev_breakpoints: &[usize],
+    prev_breakpoint_hashes: &[[u8; 32]],
+    internal_tip: Option<usize>,
+    prev_tip_hash: Option<[u8; 32]>,
+    new_breakpoint_hashes: &[[u8; 32]],
+    cap: usize,
+) -> usize {
+    let new_set: std::collections::HashSet<&[u8; 32]> =
+        new_breakpoint_hashes.iter().collect();
+    let mut picked: usize = 0;
+    for (pos, h) in prev_breakpoints.iter().zip(prev_breakpoint_hashes.iter()) {
+        if *pos <= cap && *pos > picked && new_set.contains(h) {
+            picked = *pos;
+        }
+    }
+    if let (Some(tip), Some(tip_h)) = (internal_tip, prev_tip_hash.as_ref()) {
+        if tip <= cap && tip > picked && new_set.contains(tip_h) {
+            picked = tip;
+        }
+    }
+    picked
 }
 
 /// Cache-reuse length for a call.
@@ -876,19 +953,56 @@ impl<B: Backend> Session<B> {
             Vec<usize>,
             Vec<SamplingMode>,
             Option<crate::DeferredGrammar>,
+            Vec<[u8; 32]>,
         ),
         SessionError,
     > {
-        let (tokens, breakpoints) = if self.prefix_cache.is_some() {
+        let (tokens, breakpoints, partial_hashes) = if self
+            .prefix_cache
+            .is_some()
+        {
             let rendered = self
                 .template
                 .render_with_breakpoints(prompt, &self.render_opts)?;
-            tokenize_with_breakpoints(&self.engine.model, &rendered)
+            // Inlines `tokenize_with_breakpoints` so we can keep
+            // the SHA-256 of each surviving partial paired with
+            // its token index. The shared helper only returns
+            // indices and applies sort+dedup, which would lose
+            // the partial→hash mapping.
+            let full_tokens = self.engine.model.tokenize(&rendered.text, true);
+            let mut pairs: Vec<(usize, [u8; 32])> =
+                Vec::with_capacity(rendered.partial_texts.len());
+            for partial in &rendered.partial_texts {
+                let partial_tokens = self.engine.model.tokenize(partial, true);
+                // Same fail-open contract as
+                // `chat_template::tokenize_with_breakpoints`:
+                // drop the breakpoint silently if the partial
+                // doesn't form a prefix of the full render.
+                if partial_tokens.len() <= full_tokens.len()
+                    && full_tokens[..partial_tokens.len()] == partial_tokens[..]
+                {
+                    pairs.push((
+                        partial_tokens.len(),
+                        hash_partial_text(partial),
+                    ));
+                }
+            }
+            pairs.sort_by_key(|(idx, _)| *idx);
+            pairs.dedup_by_key(|(idx, _)| *idx);
+            let breakpoints: Vec<usize> =
+                pairs.iter().map(|(idx, _)| *idx).collect();
+            let hashes: Vec<[u8; 32]> =
+                pairs.into_iter().map(|(_, h)| h).collect();
+            (full_tokens, breakpoints, hashes)
         } else {
             // Fast path: single render + tokenize, no partials.
             let rendered =
                 self.template.render_with(prompt, &self.render_opts)?;
-            (self.engine.model.tokenize(&rendered, true), Vec::new())
+            (
+                self.engine.model.tokenize(&rendered, true),
+                Vec::new(),
+                Vec::new(),
+            )
         };
 
         let (grammar_mode, deferred) = match resolve_grammar(
@@ -920,7 +1034,7 @@ impl<B: Backend> Session<B> {
                 .chain(grammar_mode.into_iter())
                 .collect()
         };
-        Ok((tokens, breakpoints, modes, deferred))
+        Ok((tokens, breakpoints, modes, deferred, partial_hashes))
     }
 
     /// Prefix-cache KV-state setup + chunked prefill shared by every
@@ -964,44 +1078,76 @@ impl<B: Backend> Session<B> {
         &mut self,
         new_tokens: &[Token],
         new_breakpoints: &[usize],
+        new_breakpoint_hashes: &[[u8; 32]],
     ) -> Result<(Vec<Token>, usize, usize), SessionError> {
         let l_hit_raw = match self.prefix_cache.as_ref() {
             Some(cache) if !cache.prev_tokens.is_empty() => {
-                let picked = compute_l_hit(
-                    &cache.prev_tokens,
-                    new_tokens,
-                    new_breakpoints,
+                // Hash-keyed fast path: if any cached breakpoint or
+                // the auto-tip hash matches a hash from the new
+                // request's partial renders, jump straight to the
+                // largest matching cached token position. Sidesteps
+                // `compute_l_hit`'s LCP — useful when the byte-level
+                // tokenization of an assistant block diverges between
+                // the model's original emission (in `prev_tokens`)
+                // and the canonical chat-template re-render (the
+                // partial_text the new request hashes).
+                let hash_picked = hash_keyed_l_hit(
+                    &cache.prev_breakpoints,
+                    &cache.prev_breakpoint_hashes,
                     cache.internal_tip,
+                    cache.prev_tip_hash,
+                    new_breakpoint_hashes,
+                    new_tokens.len(),
                 );
-                // Diagnostic: when the auto-tip is set but didn't win,
-                // log enough state to attribute the loss. The case worth
-                // attention is `tip > safe` — the LCP cut off shorter
-                // than `prev_tokens` length, almost always a BPE
-                // re-tokenization mismatch in the assistant content.
-                // `prev_at_lcp` and `new_at_lcp` point at the first
-                // divergent token; comparing them tells us whether it's
-                // a single-token shift or a wholesale re-render
-                // (thoughts stripped, JSON re-serialized, etc.).
-                #[cfg(feature = "axum")]
-                if let Some(tip) = cache.internal_tip {
-                    let lcp = longest_common_prefix_len(
+                if hash_picked > 0 {
+                    #[cfg(feature = "axum")]
+                    tracing::debug!(
+                        hash_picked,
+                        prev_len = cache.prev_tokens.len(),
+                        new_len = new_tokens.len(),
+                        "hash-keyed prefix-reuse: cached position matched by SHA-256 of partial render",
+                    );
+                    // Use the hash-matched position directly. Skip the
+                    // LCP path below — we trust the hash equality
+                    // (canonical chat-template render produced the
+                    // same bytes for the cached prefix), accepting
+                    // the BPE-drift caveat at the splice for
+                    // permissive-grammar emissions like cogito.
+                    hash_picked
+                } else {
+                    let picked = compute_l_hit(
                         &cache.prev_tokens,
                         new_tokens,
+                        new_breakpoints,
+                        cache.internal_tip,
                     );
-                    let safe = lcp.saturating_sub(1);
-                    if tip > safe && tip > picked {
-                        let prev_len = cache.prev_tokens.len();
-                        let new_len = new_tokens.len();
-                        let prev_at_lcp = cache
-                            .prev_tokens
-                            .get(lcp)
-                            .copied()
-                            .unwrap_or(-1);
-                        let new_at_lcp = new_tokens
-                            .get(lcp)
-                            .copied()
-                            .unwrap_or(-1);
-                        tracing::debug!(
+                    // Diagnostic: when the auto-tip is set but didn't win,
+                    // log enough state to attribute the loss. The case worth
+                    // attention is `tip > safe` — the LCP cut off shorter
+                    // than `prev_tokens` length, almost always a BPE
+                    // re-tokenization mismatch in the assistant content.
+                    // `prev_at_lcp` and `new_at_lcp` point at the first
+                    // divergent token; comparing them tells us whether it's
+                    // a single-token shift or a wholesale re-render
+                    // (thoughts stripped, JSON re-serialized, etc.).
+                    #[cfg(feature = "axum")]
+                    if let Some(tip) = cache.internal_tip {
+                        let lcp = longest_common_prefix_len(
+                            &cache.prev_tokens,
+                            new_tokens,
+                        );
+                        let safe = lcp.saturating_sub(1);
+                        if tip > safe && tip > picked {
+                            let prev_len = cache.prev_tokens.len();
+                            let new_len = new_tokens.len();
+                            let prev_at_lcp = cache
+                                .prev_tokens
+                                .get(lcp)
+                                .copied()
+                                .unwrap_or(-1);
+                            let new_at_lcp =
+                                new_tokens.get(lcp).copied().unwrap_or(-1);
+                            tracing::debug!(
                             tip,
                             lcp,
                             safe,
@@ -1013,9 +1159,10 @@ impl<B: Backend> Session<B> {
                             "auto-tip ineligible: tip past safe (LCP shorter than expected — \
                              likely re-tokenization mismatch in asst content)",
                         );
+                        }
                     }
+                    picked
                 }
-                picked
             }
             _ => 0,
         };
@@ -1135,6 +1282,31 @@ impl<B: Backend> Session<B> {
         }
     }
 
+    /// SHA-256 of the canonical chat-template render of `prompt` with
+    /// the just-generated assistant `blocks` appended as an additional
+    /// message turn, rendered with `add_generation_prompt = false`. The
+    /// resulting bytes are exactly what a subsequent request's
+    /// `partial_text` would produce when the client places a
+    /// `cache_control` marker on (or just past) that assistant message
+    /// — making this hash the cache key for the auto-tip.
+    ///
+    /// Errors propagate from `ChatTemplate::render_with`; callers
+    /// should treat the hash as best-effort and fall back to no tip
+    /// hash on error.
+    fn compute_tip_hash(
+        &self,
+        prompt: &Prompt,
+        blocks: &[crate::Block],
+    ) -> Result<[u8; 32], SessionError> {
+        let mut extended = prompt.clone().into_static();
+        let asst: misanthropic::prompt::message::AssistantMessage<'static> =
+            blocks.iter().cloned().collect();
+        extended.messages.push(asst.into());
+        let opts = self.render_opts.clone().with_generation_prompt(false);
+        let rendered = self.template.render_with(&extended, &opts)?;
+        Ok(hash_partial_text(&rendered))
+    }
+
     /// After a batch call succeeds, update [`self.prefix_cache`] to
     /// describe the current KV state: full prompt tokens **plus
     /// generated content** (`new_tokens` is the engine's exact KV
@@ -1146,6 +1318,12 @@ impl<B: Backend> Session<B> {
     /// tip's snapshot is freed via [`Engine::forget_pos`] — without
     /// this, tip snapshots accumulate one per call in moeflux's LRU.
     ///
+    /// `new_breakpoint_hashes` parallels `new_breakpoints` (same
+    /// indexing) and stores SHA-256 of each surviving partial render;
+    /// `tip_hash` stores the same for the auto-tip position. Both are
+    /// consulted by [`compute_l_hit`]'s hash-keyed fast path on
+    /// subsequent calls.
+    ///
     /// No-op when caching is off.
     fn record_cache_hit(
         &mut self,
@@ -1153,6 +1331,8 @@ impl<B: Backend> Session<B> {
         new_breakpoints: Vec<usize>,
         l_hit: usize,
         internal_tip: Option<usize>,
+        new_breakpoint_hashes: Vec<[u8; 32]>,
+        tip_hash: Option<[u8; 32]>,
     ) {
         // Capture the old tip BEFORE overwriting — needed for the
         // explicit-eviction fast path so the engine can free the prior
@@ -1167,6 +1347,8 @@ impl<B: Backend> Session<B> {
             cache.prev_breakpoints = new_breakpoints;
             cache.last_reused_tokens = l_hit;
             cache.internal_tip = internal_tip;
+            cache.prev_breakpoint_hashes = new_breakpoint_hashes;
+            cache.prev_tip_hash = tip_hash;
         }
         if let (Some(old), Some(new)) = (old_tip, internal_tip) {
             if old != new
@@ -1244,12 +1426,16 @@ impl<B: Backend> Session<B> {
         &mut self,
         prompt: &Prompt,
     ) -> Result<String, SessionError> {
-        let (tokens, breakpoints, modes, deferred_grammar) =
+        let (tokens, breakpoints, modes, deferred_grammar, partial_hashes) =
             self.prepare_call_cached(prompt, true)?;
         let prompt_tokens = tokens.len();
 
-        let (suffix, cache_read, prefill_start) =
-            self.kv_setup_and_chunk_prefill(&tokens, &breakpoints)?;
+        let (suffix, cache_read, prefill_start) = self
+            .kv_setup_and_chunk_prefill(
+                &tokens,
+                &breakpoints,
+                &partial_hashes,
+            )?;
 
         let mut predict_opts =
             PredictOptions::default().add_model_stops(&self.engine.model);
@@ -1314,11 +1500,17 @@ impl<B: Backend> Session<B> {
             self.engine.checkpoint_pos(0, head as i32);
         }
 
+        // `complete_text` doesn't parse blocks, so we have no
+        // structured assistant content to canonical-render for the tip
+        // hash. Pass `None`; the breakpoint hash side-table still
+        // covers the explicit cache_control markers.
         self.record_cache_hit(
             extended_prev,
             breakpoints,
             cache_read,
             internal_tip,
+            partial_hashes,
+            None,
         );
         let usage =
             Self::make_usage(prompt_tokens, cache_read, generated_count);
@@ -1426,12 +1618,16 @@ impl<B: Backend> Session<B> {
         &'s mut self,
         prompt: &Prompt,
     ) -> Result<BlockStream<'s, B>, SessionError> {
-        let (tokens, breakpoints, modes, deferred_grammar) =
+        let (tokens, breakpoints, modes, deferred_grammar, partial_hashes) =
             self.prepare_call_cached(prompt, true)?;
         let prompt_tokens = tokens.len();
 
-        let (suffix, cache_read, prefill_start) =
-            self.kv_setup_and_chunk_prefill(&tokens, &breakpoints)?;
+        let (suffix, cache_read, prefill_start) = self
+            .kv_setup_and_chunk_prefill(
+                &tokens,
+                &breakpoints,
+                &partial_hashes,
+            )?;
 
         // Streaming: the cache must be updated BEFORE the predictor
         // borrows `&mut self.engine`, because the returned stream
@@ -1446,7 +1642,18 @@ impl<B: Backend> Session<B> {
         // for further turns, so passing `None` for the tip is fine —
         // the breakpoint-only path still works exactly as before.
         // (See plan: streaming tip extension is a v2 follow-up.)
-        self.record_cache_hit(tokens, breakpoints, cache_read, None);
+        // Streaming path: no parsed assistant content available at
+        // setup time, and tip extension itself is a v2 follow-up
+        // (see comment above). Pass `None` for tip_hash; breakpoint
+        // hash side-table still covers explicit cache_control markers.
+        self.record_cache_hit(
+            tokens,
+            breakpoints,
+            cache_read,
+            None,
+            partial_hashes,
+            None,
+        );
         let usage = Self::make_usage(prompt_tokens, cache_read, 0);
         self.record_usage(usage);
 
@@ -1513,12 +1720,16 @@ impl<B: Backend> Session<B> {
             Some(ToolChoice::Method { .. }) | Some(ToolChoice::Any)
         );
 
-        let (tokens, breakpoints, modes, deferred_grammar) =
+        let (tokens, breakpoints, modes, deferred_grammar, partial_hashes) =
             self.prepare_call_cached(prompt, true)?;
         let prompt_tokens = tokens.len();
 
-        let (suffix, cache_read, prefill_start) =
-            self.kv_setup_and_chunk_prefill(&tokens, &breakpoints)?;
+        let (suffix, cache_read, prefill_start) = self
+            .kv_setup_and_chunk_prefill(
+                &tokens,
+                &breakpoints,
+                &partial_hashes,
+            )?;
 
         // Pieces we drop from the surfaced output: the primary EOS,
         // the EOT (if distinct), every extra-EOS the model declares
@@ -1662,6 +1873,26 @@ impl<B: Backend> Session<B> {
             self.engine.checkpoint_pos(0, head as i32);
         }
 
+        // Compute the auto-tip hash from the parsed assistant blocks
+        // — `run_call` is the only completion path with parsed
+        // structure available at save-time, so this is where the tip
+        // entry of the hash side-table actually gets populated. Best-
+        // effort: a render error logs and falls back to no tip hash
+        // (cache still works, just without the auto-tip side-table
+        // entry).
+        let blocks_owned: Vec<crate::Block> =
+            blocks.iter().cloned().map(|b| b.into_static()).collect();
+        let tip_hash = match self.compute_tip_hash(prompt, &blocks_owned) {
+            Ok(h) => Some(h),
+            Err(_e) => {
+                #[cfg(feature = "axum")]
+                tracing::debug!(
+                    "compute_tip_hash failed; tip hash side-table entry skipped"
+                );
+                None
+            }
+        };
+
         // Cache + usage bookkeeping, then grammar-violation check.
         // Check last so a violation still records the work that was
         // done — usage numbers are correct either way.
@@ -1670,6 +1901,8 @@ impl<B: Backend> Session<B> {
             breakpoints,
             cache_read,
             internal_tip,
+            partial_hashes,
+            tip_hash,
         );
         let usage =
             Self::make_usage(prompt_tokens, cache_read, generated_count);
@@ -2936,5 +3169,179 @@ mod tests {
             Some(0),
             "post-clear call must miss",
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Hash-keyed prefix-reuse tests — pure-Rust, no model.
+    // -----------------------------------------------------------------
+
+    /// `hash_partial_text` is deterministic: same input bytes always
+    /// produce the same SHA-256 digest.
+    #[test]
+    fn test_hash_partial_text_determinism() {
+        let s = "<|im_start|>user\nhello\n<|im_end|>\n";
+        let a = hash_partial_text(s);
+        let b = hash_partial_text(s);
+        assert_eq!(a, b);
+    }
+
+    /// Different content → different hash. Guards against the
+    /// degenerate-hash failure mode (e.g. constant-output stub).
+    #[test]
+    fn test_hash_partial_text_diverges_on_content() {
+        let a = hash_partial_text("<tool_call>{\"id\": \"x\"}</tool_call>");
+        let b = hash_partial_text("<tool_call>{\"id\":\"x\"}</tool_call>");
+        // Whitespace difference is exactly the bug the chat-template
+        // canonical-render hash is *meant* to bypass at a higher
+        // level, but at this layer the function must distinguish
+        // distinct byte strings.
+        assert_ne!(a, b);
+    }
+
+    /// Single matching breakpoint hash → returns its position.
+    #[test]
+    fn test_hash_keyed_l_hit_single_breakpoint_match() {
+        let h_a = hash_partial_text("aaa");
+        let h_b = hash_partial_text("bbb");
+        let prev_breakpoints = vec![100usize];
+        let prev_hashes = vec![h_a];
+        // New request has hash matching cached breakpoint.
+        let new_hashes = vec![h_a];
+        assert_eq!(
+            hash_keyed_l_hit(
+                &prev_breakpoints,
+                &prev_hashes,
+                None,
+                None,
+                &new_hashes,
+                500,
+            ),
+            100
+        );
+        // Different hash → no match.
+        let new_hashes_no_match = vec![h_b];
+        assert_eq!(
+            hash_keyed_l_hit(
+                &prev_breakpoints,
+                &prev_hashes,
+                None,
+                None,
+                &new_hashes_no_match,
+                500,
+            ),
+            0
+        );
+    }
+
+    /// With matches at positions 100 and 200, the lookup picks 200
+    /// (largest matching cached position).
+    #[test]
+    fn test_hash_keyed_l_hit_picks_longest_match() {
+        let h_a = hash_partial_text("aaa");
+        let h_b = hash_partial_text("bbb");
+        let h_c = hash_partial_text("ccc");
+        let prev_breakpoints = vec![100, 200, 300];
+        let prev_hashes = vec![h_a, h_b, h_c];
+        // New request matches 100 and 200 only (not 300).
+        let new_hashes = vec![h_a, h_b];
+        assert_eq!(
+            hash_keyed_l_hit(
+                &prev_breakpoints,
+                &prev_hashes,
+                None,
+                None,
+                &new_hashes,
+                500,
+            ),
+            200,
+            "should pick the largest matching cached position",
+        );
+    }
+
+    /// Tip hash beats breakpoint hashes when its position is larger
+    /// and matches.
+    #[test]
+    fn test_hash_keyed_l_hit_tip_beats_breakpoint() {
+        let h_bp = hash_partial_text("aaa");
+        let h_tip = hash_partial_text("bbb");
+        let prev_breakpoints = vec![100];
+        let prev_hashes = vec![h_bp];
+        let new_hashes = vec![h_bp, h_tip];
+        // Tip at 250 with matching hash should win over bp at 100.
+        assert_eq!(
+            hash_keyed_l_hit(
+                &prev_breakpoints,
+                &prev_hashes,
+                Some(250),
+                Some(h_tip),
+                &new_hashes,
+                500,
+            ),
+            250,
+        );
+    }
+
+    /// `cap` argument bounds the result — a cached position > cap is
+    /// rejected even if the hash matches. Protects against claiming
+    /// to reuse more tokens than the new request has.
+    #[test]
+    fn test_hash_keyed_l_hit_cap_bound() {
+        let h = hash_partial_text("aaa");
+        let prev_breakpoints = vec![100, 800];
+        let prev_hashes = vec![h, h];
+        let new_hashes = vec![h];
+        // Cap at 500 → 800 rejected, falls back to 100.
+        assert_eq!(
+            hash_keyed_l_hit(
+                &prev_breakpoints,
+                &prev_hashes,
+                None,
+                None,
+                &new_hashes,
+                500,
+            ),
+            100,
+        );
+    }
+
+    /// No match at all → returns 0.
+    #[test]
+    fn test_hash_keyed_l_hit_no_match() {
+        let h_a = hash_partial_text("aaa");
+        let h_b = hash_partial_text("bbb");
+        let prev_breakpoints = vec![100, 200];
+        let prev_hashes = vec![h_a, h_a];
+        let new_hashes = vec![h_b];
+        assert_eq!(
+            hash_keyed_l_hit(
+                &prev_breakpoints,
+                &prev_hashes,
+                Some(300),
+                Some(h_b),
+                &new_hashes,
+                500,
+            ),
+            300,
+            "tip with matching hash should still win even when bps miss",
+        );
+        assert_eq!(
+            hash_keyed_l_hit(
+                &prev_breakpoints,
+                &prev_hashes,
+                Some(300),
+                Some(h_a),
+                &new_hashes,
+                500,
+            ),
+            0,
+            "no hashes match → 0",
+        );
+    }
+
+    /// Empty side-table → 0, regardless of new hashes.
+    #[test]
+    fn test_hash_keyed_l_hit_empty_side_table() {
+        let h = hash_partial_text("aaa");
+        assert_eq!(hash_keyed_l_hit(&[], &[], None, None, &[h], 500), 0);
     }
 }

--- a/tests/hash_cache_smoke.rs
+++ b/tests/hash_cache_smoke.rs
@@ -1,0 +1,197 @@
+//! Hash-keyed prefix-reuse end-to-end smoke test.
+//!
+//! Two-round conversation with a `Block::ToolUse` carrying a JSON
+//! `input` — the case where the model's emitted whitespace can diverge
+//! from `serde_json::to_string`'s canonical re-rendering between
+//! rounds. Without hash-keyed reuse, the LCP / auto-tip path cuts off
+//! at the first JSON-whitespace divergence (the cogito repro Mike
+//! captured 2026-05-08 in the auto-tip-debug branch).
+//!
+//! With this PR's hash side-table, round 2's `partial_text` for the
+//! conversation prefix matches the auto-tip hash drama_llama saved at
+//! the end of round 1's generation, so cache_read jumps to ≈
+//! input_tokens for the round-2 prefill regardless of any
+//! BPE-whitespace drift in the assistant block.
+//!
+//! Requires a real model. Set `DRAMA_LLAMA_COGITO_MODEL` to a cogito-
+//! style GGUF for the most direct repro of the original bug; falls
+//! back to `models/model.gguf` (any tool-using chat model works for
+//! the hash-side-table mechanic — cogito is just where the whitespace
+//! divergence is most pronounced).
+//!
+//! Ignored by default: `cargo test --test hash_cache_smoke -- --ignored`.
+
+#![cfg(feature = "llama-cpp")]
+
+use std::{borrow::Cow, path::PathBuf};
+
+use drama_llama::{
+    prompt::{ToolResult, ToolUse},
+    Block, Content, Message, Prompt, Role, Session, Tool,
+};
+use misanthropic::prompt::message::CacheControl;
+use serde_json::json;
+
+fn model_path() -> PathBuf {
+    if let Ok(p) = std::env::var("DRAMA_LLAMA_COGITO_MODEL") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("models/model.gguf")
+}
+
+/// Build the round-1 prompt: a tool, a system prompt, and a user
+/// message asking the model to call the tool. `cache_control` on the
+/// user message gives drama_llama a breakpoint to anchor the prefix
+/// (system+tools+first_user_msg) — the same shape agora seeds.
+fn build_round1() -> (Prompt, Tool) {
+    let tool = Tool {
+        name: Cow::Borrowed("count_letters"),
+        description: Cow::Borrowed(
+            "Count the number of times a letter appears in a string.",
+        ),
+        schema: json!({
+            "type": "object",
+            "properties": {
+                "letter": {"type": "string"},
+                "string": {"type": "string"}
+            },
+            "required": ["letter", "string"]
+        }),
+        cache_control: None,
+        strict: None,
+    };
+
+    let prompt = Prompt {
+        system: Some(Content::SinglePart(Cow::Borrowed(
+            "You are a helpful assistant. Use the provided tool when answering.",
+        ))),
+        messages: vec![Message {
+            role: Role::User,
+            content: Content::MultiPart(vec![Block::Text {
+                text: Cow::Borrowed(
+                    "Count the number of r's in 'strawberry'.",
+                ),
+                cache_control: Some(CacheControl::ephemeral()),
+            }]),
+        }],
+        functions: Some(vec![tool.clone()]),
+        ..Prompt::default()
+    };
+
+    (prompt, tool)
+}
+
+/// Extend the round-1 prompt with the assistant's tool_use response,
+/// a tool_result, and a follow-up user message. `cache_control` on
+/// the follow-up gives drama_llama a fresh breakpoint at the new tip.
+fn build_round2(
+    base_prompt: &Prompt,
+    tool_use: ToolUse,
+    result_text: &str,
+) -> Prompt {
+    let call_id = tool_use.id.clone();
+    let mut prompt = base_prompt.clone().into_static();
+    prompt.messages.push(Message {
+        role: Role::Assistant,
+        content: Content::MultiPart(vec![Block::ToolUse { call: tool_use }]),
+    });
+    prompt.messages.push(Message {
+        role: Role::User,
+        content: Content::MultiPart(vec![
+            Block::ToolResult {
+                result: ToolResult {
+                    tool_use_id: call_id,
+                    content: Content::SinglePart(Cow::Owned(
+                        result_text.to_string(),
+                    )),
+                    is_error: false,
+                    cache_control: None,
+                },
+            },
+            Block::Text {
+                text: Cow::Borrowed("Thanks. Now spell that word backwards."),
+                cache_control: Some(CacheControl::ephemeral()),
+            },
+        ]),
+    });
+    prompt
+}
+
+#[test]
+#[ignore = "requires model; sets DRAMA_LLAMA_COGITO_MODEL or models/model.gguf"]
+fn hash_keyed_prefix_reuse_carries_across_tool_use_round_trip() {
+    let mut session = Session::from_path(model_path())
+        .expect("model loads")
+        .quiet()
+        .with_prefix_cache(true);
+
+    let (round1_prompt, _tool) = build_round1();
+
+    // Round 1: complete and capture the assistant's first tool_use
+    // (or fall back to a synthetic one if the model produced text
+    // without a tool call — the test's mechanic still holds).
+    let round1_resp = session
+        .complete_response(&round1_prompt)
+        .expect("round 1 completes");
+    let round1_input_tokens = round1_resp.usage.input_tokens;
+    let round1_cache_read = round1_resp.usage.cache_read_input_tokens;
+    eprintln!(
+        "round 1: input_tokens={}, cache_read={}",
+        round1_input_tokens,
+        round1_cache_read.unwrap_or(0),
+    );
+
+    // Find the tool_use block in the response — needed for round 2's
+    // re-rendering. If the model produced text only, synthesize a
+    // dummy ToolUse so we still exercise the hash-cache code path.
+    let blocks_round1: Vec<Block> =
+        round1_resp.inner.content().clone().into_iter().collect();
+    let tool_use = blocks_round1
+        .into_iter()
+        .find_map(|b| match b {
+            Block::ToolUse { call } => Some(call),
+            _ => None,
+        })
+        .unwrap_or_else(|| ToolUse {
+            id: Cow::Borrowed("synthetic_call_1"),
+            name: Cow::Borrowed("count_letters"),
+            input: json!({"letter": "r", "string": "strawberry"}),
+            cache_control: None,
+        });
+
+    // Round 2: extend the conversation; cache_read should jump from
+    // ~prefix-only (system+tools+first_user_msg) to ~all-of-round-1
+    // (auto-tip hit) when hash-keyed reuse fires.
+    let round2_prompt = build_round2(&round1_prompt, tool_use, "3");
+    let round2_resp = session
+        .complete_response(&round2_prompt)
+        .expect("round 2 completes");
+    let round2_input_tokens = round2_resp.usage.input_tokens;
+    let round2_cache_read =
+        round2_resp.usage.cache_read_input_tokens.unwrap_or(0);
+    eprintln!(
+        "round 2: input_tokens={}, cache_read={}",
+        round2_input_tokens, round2_cache_read,
+    );
+
+    // The minimal floor: round 2 must cache-read at least the
+    // round-1 input prefix (the first cache_control marker's
+    // breakpoint). That's already true today via the breakpoint
+    // path. The interesting assertion: cache_read should reach the
+    // auto-tip — i.e., should exceed round-1's *full* input length
+    // (system + tools + first_user_msg + assistant + tool_result),
+    // capturing the assistant content as well. We pick a permissive
+    // threshold (round-1 input + 50% of round-1 generation tokens,
+    // floored at round-1 input + 1) so the test passes whenever the
+    // tip mechanism is live, even with single-token BPE drift.
+    let round1_gen = round1_resp.usage.output_tokens;
+    let tip_floor = (round1_input_tokens + (round1_gen / 2).max(1))
+        .max(round1_input_tokens + 1);
+    assert!(
+        round2_cache_read >= tip_floor,
+        "round 2 cache_read ({round2_cache_read}) should reach the auto-tip ({tip_floor}); \
+         hash-keyed reuse appears not to be firing. \
+         (input_tokens={round2_input_tokens}, round1_input={round1_input_tokens}, \
+         round1_gen={round1_gen})",
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a hash side-table to `PrefixCache` so the auto-tip + cache_control breakpoints survive between calls when the byte-level tokenization of an assistant block diverges between the model's original emission (in `prev_tokens`) and the chat-template canonical re-render (what the next call tokenizes from).
- The repro case is cogito-32b: its permissive JSON grammar (`src/sample/json.rs:125-209`, whitespace `Ok(())`-skipped at every state) lets the model emit varying whitespace across calls. drama_llama parses model output into `Block::ToolUse { input: serde_json::Value }`, dropping the original whitespace; on the next round chat_template re-renders via `serde_json::to_string`, which uses serde's canonical whitespace. `prev_tokens` (model-emission view) and `new_tokens` (canonical-render view) diverge at the first JSON-whitespace mismatch and the existing LCP / `lcp-1` BPE-safety check cuts off well before the auto-tip.
- Hash side-table sidesteps this. We hash each surviving `partial_text` returned by `tokenize_with_breakpoints` and store the hash paired with its token position. On the next call we hash each new `partial_text` and pick the largest matching cached token position via `hash_keyed_l_hit`, falling through to `compute_l_hit` when no hash matches. The hash key is the chat-template render — independent of `cache_control` metadata (markers move legitimately across calls), but fully sensitive to source content. We accept single-token BPE drift at the splice for permissive-grammar emissions.

Built on top of `fork/auto-tip-debug` (commit `dee33db`); base targets v0.8.0 since the debug-log instrumentation is the diagnostic entry point that confirmed the bug.

## Plumbing

- `prepare_call_cached` returns one extra `Vec<[u8; 32]>` of partial hashes, inlining the relevant `chat_template::tokenize_with_breakpoints` logic so per-partial hashes survive sort+dedup.
- `kv_setup_and_chunk_prefill` takes the new request's partial hashes and consults the cache's `prev_breakpoint_hashes` + `prev_tip_hash` before falling through to `compute_l_hit`.
- `record_cache_hit` takes the new breakpoint hashes + tip hash and stores them on `PrefixCache` alongside `prev_tokens` / `prev_breakpoints` / `internal_tip`.
- New helpers: `hash_partial_text(text) -> [u8; 32]` (sha2::Sha256), `hash_keyed_l_hit(...) -> usize` (pure-function lookup over the side table, capped at `new_tokens.len()`), `Session::compute_tip_hash`.
- The tip side-table entry is populated only on the `run_call` path (`complete_response` / `complete_blocks` / `complete`) where parsed assistant blocks are available — `compute_tip_hash` re-renders `prompt + assistant_blocks` with `add_generation_prompt = false` and hashes the full render. `complete_text` and `complete_stream` lack parsed structure at save time; tip_hash stays `None` there. Breakpoint hashes still populate from `prepare_call_cached`'s render in all three paths.

## Test plan

- [x] `cargo check --features axum,cli,toml` clean
- [x] `cargo build --features axum,cli,toml --bin blallama` clean
- [x] `cargo test --features axum,cli,toml --lib -- --skip 'llama_cpp::model::tests'` (234 passed, 0 failed; 4 skipped pre-existing model-required tests)
- [x] 7 new unit tests in `src/session/mod.rs` covering: hash determinism, content sensitivity, longest-match wins, tip-beats-breakpoint, cap-bound, no-match returns 0, empty side-table returns 0
- [ ] New `tests/hash_cache_smoke.rs` end-to-end (#[ignore]; honors `DRAMA_LLAMA_COGITO_MODEL` env var, falls back to `models/model.gguf`) — runs locally with a real model
- [ ] Deploy to balerion, rerun the 2-agent aegis-aether/aegis-anchor seed against blallama; expected: `auto-tip ineligible` debug warnings drop dramatically, `cache_read_input_tokens` approaches `input_tokens` for fresh rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)