### PR TITLE
fix(session): reset constraint matchers on tip resume into a new turn (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this crate are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] — 2026-07-24
+
+### Fixed
+
+- **Tip resume into a new assistant turn no longer forces an
+  immediate EOS** (the 0-output-token second-round bug). A cached
+  tip's `SamplerState` carries constraint-matcher positions on
+  grammar identity — correct for assistant-prefill / partial-
+  completion resume, but wrong when the new call seats the generated
+  turn plus a tool result: the matcher arrived parked at
+  tool-call-complete, where the only legal continuation is the turn
+  terminator, so every second acting round of an agentic session
+  generated zero tokens (reproduced on both Qwen 3.6 and gpt-oss —
+  template-independent). `Session::build_initial_state` now resets
+  matchers (eager, JSON, and deferred) to their grammar roots when
+  the fold has messages past the resume cursor
+  (`matcher_carry_valid`); the prose stream (rng, mirostat `mu`,
+  n-gram stats) still carries. `hash_cache_smoke` — which exercised
+  the exact failing shape but asserted only cache-read counters —
+  now also asserts round 2 produces output: cache stats are not a
+  proxy for generation.
+
 ## [0.8.0] — 2026-07-24
 
 Backend split. The chat-style API (`Session`), the engine layer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drama_llama"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 # The stable toolchain CI actually tests (nothing older is ever built
 # here, so a lower claim would be untested). Bump freely alongside CI's

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/mdegans/drama_llama/actions/workflows/ci.yml/badge.svg)](https://github.com/mdegans/drama_llama/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/mdegans/drama_llama/graph/badge.svg)](https://codecov.io/gh/mdegans/drama_llama)
-[![tests](https://img.shields.io/badge/tests-600-blue)](#testing)
+[![tests](https://img.shields.io/badge/tests-603-blue)](#testing)
 [![license](https://img.shields.io/badge/license-RAIL--S-lightgrey)](https://github.com/mdegans/drama_llama/blob/main/LICENSE.md)
 
 `drama_llama` runs language models on your own hardware behind an API shaped
@@ -207,7 +207,7 @@ sampler-settings editor).
 
 ## Testing
 
-600 tests across 27 binaries in the default configuration — 481 that run in
+603 tests across 27 binaries in the default configuration — 484 that run in
 seconds and 119 that load real weights onto a real accelerator. The
 model-backed tier is `#[ignore]`d so the fast loop stays fast, and the whole
 topology — *which features* × *which tests* — lives in one place,

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -742,8 +742,15 @@ def cmd_check(args: argparse.Namespace) -> int:
     Note it does NOT cover doctests: `cargo check` does not compile them.
     That is `doctest`'s job, and it is why that subcommand sweeps
     configurations too rather than running just one.
+
+    Since 2026-07-24 this also runs the `badge` verification (the
+    llama-cpp-cpu configuration, same as CI's badge step), so a stale
+    README test count fails at the pre-commit hook instead of ~40
+    minutes later in CI — the 0.8.1 PR hit exactly that. On a warm
+    tree `cargo nextest list` is near-free; on a cold tree it builds
+    the cpu test binaries once, which is the price of the gate.
     """
-    return sweep(
+    rc = sweep(
         "check",
         selected_configs(args.config, args.moeflux_model, args.ci),
         lambda features: [
@@ -754,6 +761,15 @@ def cmd_check(args: argparse.Namespace) -> int:
             "--features",
             ",".join(features),
         ],
+    )
+    if rc != 0:
+        return rc
+    return cmd_badge(
+        argparse.Namespace(
+            config="llama-cpp-cpu",
+            moeflux_model=args.moeflux_model,
+            fix=False,
+        )
     )
 
 
@@ -891,8 +907,12 @@ def cmd_badge(args: argparse.Namespace) -> int:
     configuration the numbers describe, and `--fix` rewrites them.
 
     CI runs this after the test job (the test binaries are already
-    built, so the list is nearly free). It is deliberately NOT in the
-    pre-commit hook: README edits are rare and the hook stays fast.
+    built, so the list is nearly free). Since 2026-07-24 `check` runs
+    it too — the pre-commit hook is now gated on it, a deliberate
+    reversal of the original "keep the hook fast" exclusion after a
+    stale badge failed the 0.8.1 PR in CI. `nextest list` on a warm
+    target dir keeps the hook cheap; a cold tree pays one cpu-config
+    test-binary build.
     """
     import json as _json
     import re as _re

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -2872,6 +2872,69 @@ mod tests {
         assert_eq!(resumed.constrained_step, 0);
     }
 
+    /// `reset_constraints` — the new-turn half of a tip resume: every
+    /// matcher returns to its grammar's root and the deferred matcher
+    /// to inactive root, while the prose stream (rng, `mu`, n-gram
+    /// stats, `step`) is untouched. Regression for the 0-output-token
+    /// round-2 bug (2026-07-24): a tip snapshot parked at
+    /// tool-call-complete carried into a NEW assistant turn masks
+    /// every candidate and forces an immediate EOS.
+    #[test]
+    fn reset_constraints_returns_matchers_to_root() {
+        let opts = opts_with_grammar(false);
+        let mut state = state_for(&opts);
+        // Walk one step into "ab": now only "b" is legal — the
+        // stale-carry shape.
+        let tok = sample(
+            cands(&[(A, 20.0), (X, 0.0), (EOS, -20.0)]),
+            &opts,
+            &mut state,
+        );
+        assert_eq!(tok, A);
+        assert!(!grammar_accepts(&opts, &state, b"a"));
+        state.mu = Some(2.5);
+        state.ngram_stats.add(crate::NGram::from(A), 2);
+        let rng_before = state.rng.clone();
+        let stats_before = state.ngram_stats.clone();
+        let step_before = state.step;
+
+        state.reset_constraints(&opts);
+        assert!(grammar_accepts(&opts, &state, b"a"), "back at root");
+        assert!(!grammar_accepts(&opts, &state, b"b"), "position dropped");
+        assert_eq!(state.mu, Some(2.5), "stream carries");
+        assert_eq!(state.rng, rng_before);
+        assert_eq!(state.ngram_stats, stats_before);
+        assert_eq!(state.step, step_before);
+    }
+
+    /// `reset_constraints` on a deferred (lazy) grammar: an activated,
+    /// mid-walk matcher returns to the inactive root — the tip shape
+    /// for `tool_choice: auto`, where the trigger had activated the
+    /// grammar and the completed call parked it at accept.
+    #[test]
+    fn reset_constraints_deactivates_deferred() {
+        let deferred = crate::DeferredGrammar {
+            grammar: CompiledGrammar::parse(AB_GRAMMAR).unwrap(),
+            activate_after: vec![b"!".to_vec()],
+            feed_trigger: false,
+        };
+        let opts = SamplerConfig {
+            modes: vec![SamplingMode::Greedy],
+            repetition: None,
+            deferred_grammar: Some(deferred),
+            lazy_grammar: true,
+            ..SamplerConfig::default()
+        };
+        let mut state = state_for(&opts);
+        if let Some(d) = state.deferred.as_mut() {
+            d.active = true;
+        }
+
+        state.reset_constraints(&opts);
+        let d = state.deferred.as_ref().expect("config has a deferred");
+        assert!(!d.active, "deferred must return to inactive");
+    }
+
     /// A populated mid-call snapshot round-trips the constrained
     /// fields bit-exactly with canonical bytes. (Blobs from a binary
     /// predating the fields deserialize via `serde(default)` — worth

--- a/src/sample/state.rs
+++ b/src/sample/state.rs
@@ -413,6 +413,46 @@ impl SamplerState {
         }
     }
 
+    /// Reset every constraint matcher (eager, JSON, deferred) to its
+    /// grammar's root, keeping the stream fields (`mu`, rng, n-gram
+    /// stats, `step`) intact.
+    ///
+    /// [`resumed_from`](Self::resumed_from) carries matcher positions
+    /// whenever the grammar identity matches, which is correct only
+    /// when generation resumes the snapshotted assistant turn itself
+    /// (assistant-prefill / partial-completion). When the new call
+    /// folds prompt content *past* the snapshot — a seated tool
+    /// result, a new user turn — the snapshotted turn has closed and
+    /// the call opens a fresh assistant turn, so a carried position
+    /// (typically parked at tool-call-complete, where only the turn
+    /// terminator is legal) would mask every real candidate and force
+    /// an immediate EOS: the 0-output-token second-round bug. The
+    /// session decides continuity (`matcher_carry_valid` in
+    /// `session::build_initial_state`); this is the reset half.
+    pub(crate) fn reset_constraints(&mut self, config: &SamplerConfig) {
+        self.matchers = config
+            .modes
+            .iter()
+            .map(|mode| match mode {
+                SamplingMode::Grammar(compiled) => MatcherState::Grammar {
+                    grammar: compiled.source_hash(),
+                    stack: compiled.root_state(),
+                },
+                SamplingMode::Json => MatcherState::Json(JsonState::new()),
+                _ => MatcherState::Stateless,
+            })
+            .collect();
+        self.deferred =
+            config
+                .deferred_grammar
+                .as_ref()
+                .map(|spec| DeferredMatcher {
+                    active: false,
+                    grammar: spec.grammar.source_hash(),
+                    matcher: spec.grammar.root_state(),
+                });
+    }
+
     /// Read-only: would `token`'s piece bring any incomplete
     /// constraint (eager matcher, or the activated deferred grammar)
     /// to its accept state — or is one already there? The predictor

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1019,6 +1019,19 @@ fn cursor_of(bp: PromptBreakpoint) -> SeedCursor {
     }
 }
 
+/// Whether a resumed snapshot's constraint-matcher positions are still
+/// valid for this call: true iff the cursor already covers every
+/// message, i.e. generation continues the snapshotted assistant turn
+/// (assistant-prefill / partial-completion — the seated reply is the
+/// last message and the tip cursor's `messages.len() + 1` covers it).
+/// False when the fold has messages left past the cursor (a seated
+/// tool result, a new user turn): the snapshotted turn closed, the
+/// call opens a fresh assistant turn, and the caller must
+/// [`SamplerState::reset_constraints`]. Pure; tested directly.
+fn matcher_carry_valid(messages_len: usize, cursor: SeedCursor) -> bool {
+    messages_len <= cursor.msgs_done
+}
+
 /// Ingest the prose blocks of `prompt` in `[from, upto)` into `state`'s
 /// n-gram stats — the block-gated prompt-seeding fold ("repetition over
 /// the running PROSE corpus, structured regions excluded").
@@ -2588,7 +2601,23 @@ impl<B: Backend> Session<B> {
         let model = &self.engine.model;
         let (mut state, from) = match (self.seed, cached) {
             (None, Some((cached, cursor))) => {
-                (SamplerState::resumed_from(&cached, config, model), cursor)
+                let mut state =
+                    SamplerState::resumed_from(&cached, config, model);
+                // The reconcile carries matcher positions on grammar
+                // identity, which is only valid when generation resumes
+                // the snapshotted assistant turn itself. If the fold
+                // has messages left past the cursor — a seated tool
+                // result, a new user turn — that turn has closed and
+                // this call opens a fresh one: a carried position
+                // (parked at tool-call-complete, where only the turn
+                // terminator is legal) would force an immediate EOS
+                // (the 0-output-token round-2 bug). The prose stream
+                // (rng / mu / n-gram stats) still carries — it measures
+                // the corpus, not turn structure.
+                if !matcher_carry_valid(prompt.messages.len(), cursor) {
+                    state.reset_constraints(config);
+                }
+                (state, cursor)
             }
             (Some(seed), _) => {
                 (config.init_state(seed.get(), model), SeedCursor::default())
@@ -6092,6 +6121,36 @@ mod tests {
                 n_pos: 16,
             },
         }
+    }
+
+    /// The tip-resume continuity rule ([`matcher_carry_valid`]):
+    /// matcher positions carry only when the cursor already covers
+    /// every message. Regression for the 0-output-token round-2 bug
+    /// (2026-07-24): a tool round-trip appends the seated assistant
+    /// turn plus a tool_result, the tip's matcher (parked at
+    /// tool-call-complete) carried into the fresh turn, and the only
+    /// legal token was EOS.
+    #[test]
+    fn matcher_carry_validity() {
+        // Round-1 tip: one message at generation time, synthesized
+        // cursor covers the appended assistant reply (msgs_done = 2).
+        let tip = SeedCursor {
+            system_done: true,
+            msgs_done: 2,
+        };
+        // Partial-completion continuation: the seated reply IS the
+        // last message (len 2) — continuous, carry stands.
+        assert!(matcher_carry_valid(2, tip));
+        // Tool round-trip: assistant + tool_result seated (len 3) —
+        // the turn closed, matchers must reset.
+        assert!(!matcher_carry_valid(3, tip));
+        // Prompt-breakpoint resume mid-history: reset (harmless —
+        // fold snapshots hold root matchers).
+        let after_msg_0 = SeedCursor {
+            system_done: true,
+            msgs_done: 1,
+        };
+        assert!(!matcher_carry_valid(3, after_msg_0));
     }
 
     /// `longest_common_prefix_len` covers the edge shapes we rely on:

--- a/tests/hash_cache_smoke.rs
+++ b/tests/hash_cache_smoke.rs
@@ -213,4 +213,21 @@ fn hash_keyed_prefix_reuse_carries_across_tool_use_round_trip() {
          (input_tokens={round2_input_tokens}, round1_input={round1_input_tokens}, \
          round1_gen={round1_gen})",
     );
+
+    // The assertion this test shipped without (2026-07-24): a tip
+    // resume must actually GENERATE. The stale-matcher-carry bug made
+    // every round 2 after a tool round-trip emit 0 tokens (the tip's
+    // grammar matcher, parked at tool-call-complete, carried into the
+    // fresh assistant turn where only the turn terminator was legal) —
+    // while this test's cache_read threshold kept passing. Cache stats
+    // are not a proxy for output.
+    assert!(
+        round2_resp.usage.output_tokens > 0,
+        "round 2 generated no tokens after the tip resume \
+         (stale constraint-matcher carry?)",
+    );
+    assert!(
+        !round2_resp.inner.content.0.is_empty(),
+        "round 2 returned an empty content array",
+    );
 }


### PR DESCRIPTION
## The bug

Round 2 of **every** agentic tool session generated exactly 0 output tokens on blallama 0.8.0 — the model's second acting turn came back as an empty content array in ~850ms. Reproduced live on both Qwen 3.6 (ChatML-family) and gpt-oss (Harmony), so template-independent. Found today during the first smoke runs of Agora's new agentkit seed runner.

## Root cause

A cached tip's `SamplerState` is snapshot-coupled with the KV, and `SamplerState::resumed_from` carries constraint-matcher positions on grammar identity. That carry is correct for assistant-prefill / partial-completion resume — but on a tool round-trip the tip's matcher is parked at **tool-call-complete** (the tip invariant keeps the terminal token from advancing matchers), where the only legal continuation is the turn terminator. Same tools ⇒ same grammar ⇒ carry ⇒ the fresh assistant turn's first sampled token can only be EOS. The seeding fold past the resume cursor is repetition-stats-only, so nothing ever reset the matchers.

Diagnosis chain, for the record: byte-identical replay of the failing request generated fine (so not the request); blallama's token accounting showed the live failure restored at the *generation tip* (12,787) while the healthy replay restored at the *marker boundary* (12,790) — the 3-token delta is the seated turn-close the model never generated. That narrowed it to the tip-coupled sampler state.

## The fix

- `SamplerState::reset_constraints` — eager, JSON, and deferred matchers back to their grammar roots; the prose stream (rng, `mu`, n-gram stats, `step`) carries, since it measures the corpus, not turn structure.
- `matcher_carry_valid` (session): positions carry **iff** the resume cursor already covers every message — i.e. generation continues the snapshotted turn itself. The tip cursor's `messages.len() + 1` makes partial-completion continuation satisfy this exactly; a seated tool_result or new user turn does not.
- Wired together in `Session::build_initial_state`'s resume arm.

## Why the suite missed it

`tests/hash_cache_smoke.rs` exercised the exact failing shape (tool round-trip through the auto-tip) but asserted only cache-read counters. It now also asserts round 2 **generates** — cache stats are not a proxy for output.

## Tests

- `matcher_carry_validity` (pure): continuation carries, tool round-trip resets, mid-history breakpoint resets.
- `reset_constraints_returns_matchers_to_root` / `reset_constraints_deactivates_deferred` (state-level, MockModel).
- `hash_cache_smoke` hardened as above.
- **Live E2E on this box** (RTX 3090, Qwen3.6-35B IQ3_S, fixed binary): 4-round agentic session, every round generated (out = 73/324/66/366/66/683), cache_read monotonic 0 → 12,566 → 13,593 → 13,679 → 14,442 → 14,445 with tip re-ingest as low as 21 tokens.

Version bumped to 0.8.1 with a CHANGELOG entry. Note: this branch was cut from `main`; the same fix will want forward-porting to `dev` if it diverges before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)