### PR TITLE
fix(sample): run the deferred grammar before the truncation samplers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this crate are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] — 2026-07-24
+
+### Fixed
+
+- **A truncation sampler can no longer starve the deferred (lazy)
+  tool-call grammar** ([#76]). An eager grammar — the forced
+  `tool_choice` path — is prepended into `SamplerConfig::modes` by the
+  session so it masks the full vocab *before* `LocallyTypical` / `TopP`
+  / `TopK` narrow it. The deferred grammar, which is not in `modes`,
+  was applied after the entire fold instead, so it only ever saw what
+  truncation left behind — frequently a single token. When that lone
+  survivor was illegal, `grammar_filter` force-EOS'd and generation
+  ended mid-structure, surfacing as
+  `SessionError::GrammarViolation`, even though thousands of legal
+  tokens existed in the full candidate set.
+
+  Because only `tool_choice: auto` builds a deferred grammar, this
+  presented as *intermittent* tool-call failures on local models under
+  auto while forced tool choice was unaffected, and it was independent
+  of `max_tokens` (reproduced identically at 2048, 4096, 8192, and
+  16384). `apply_modes` now runs the deferred grammar first, at the
+  same point an eager grammar runs. Reproduced end-to-end on
+  gpt-oss-20b via a multi-round agentic tool session, where it failed
+  on the first acting round every time and passes 8/8 rounds after.
+
 ## [0.8.1] — 2026-07-24
 
 ### Fixed
@@ -959,3 +984,4 @@ flip `DRAMA_LLAMA_DFA_CACHE=0`.
 [#54]: https://github.com/mdegans/drama_llama/issues/54
 [#60]: https://github.com/mdegans/drama_llama/issues/60
 [#68]: https://github.com/mdegans/drama_llama/issues/68
+[#76]: https://github.com/mdegans/drama_llama/issues/76

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drama_llama"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 # The stable toolchain CI actually tests (nothing older is ever built
 # here, so a lower claim would be untested). Bump freely alongside CI's

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/mdegans/drama_llama/actions/workflows/ci.yml/badge.svg)](https://github.com/mdegans/drama_llama/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/mdegans/drama_llama/graph/badge.svg)](https://codecov.io/gh/mdegans/drama_llama)
-[![tests](https://img.shields.io/badge/tests-603-blue)](#testing)
+[![tests](https://img.shields.io/badge/tests-604-blue)](#testing)
 [![license](https://img.shields.io/badge/license-RAIL--S-lightgrey)](https://github.com/mdegans/drama_llama/blob/main/LICENSE.md)
 
 `drama_llama` runs language models on your own hardware behind an API shaped
@@ -207,7 +207,7 @@ sampler-settings editor).
 
 ## Testing
 
-603 tests across 27 binaries in the default configuration — 484 that run in
+604 tests across 27 binaries in the default configuration — 485 that run in
 seconds and 119 that load real weights onto a real accelerator. The
 model-backed tier is `#[ignore]`d so the fast loop stays fast, and the whole
 topology — *which features* × *which tests* — lives in one place,

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1552,13 +1552,29 @@ pub(crate) fn sample_token<M: crate::backend::Model + Sync>(
     Ok(chosen)
 }
 
-/// Fold `candidates` through `opts.modes` in order (plus the activated
-/// deferred grammar, if any — it runs last, matching its old
-/// pushed-to-the-end promotion position). With `skip_constraints`, the
-/// `Grammar`/`Json` arms pass candidates through untouched (the lazy
-/// fast path); every other mode still runs, so `Deny` reserved-token
-/// protection, truncation samplers, and mirostat behave identically on
-/// both paths.
+/// Fold `candidates` through `opts.modes` in order, with the activated
+/// deferred grammar (if any) applied **first** — before the mode chain.
+///
+/// Ordering is load-bearing, not cosmetic. An eager grammar is
+/// *prepended* to `opts.modes` by the session (`Session::predict_options_for`)
+/// precisely so it masks the full vocab before any truncation sampler
+/// narrows it; the deferred grammar has to run at the same point for
+/// the same reason. It used to run last — after the fold — which meant
+/// it only ever saw what `LocallyTypical`/`TopP`/`TopK` left behind,
+/// often a single token. When that handful contained no
+/// grammar-legal token, `grammar_filter` force-EOS'd and generation
+/// died mid-structure (surfacing as `SessionError::GrammarViolation`)
+/// even though thousands of legal tokens existed in the full vocab.
+///
+/// That asymmetry made `tool_choice: auto` — the only path that builds
+/// a deferred grammar — fail intermittently on local models while
+/// forced tool choice, which takes the eager path, was fine. See
+/// mdegans/drama_llama#76.
+///
+/// With `skip_constraints`, the `Grammar`/`Json` arms and the deferred
+/// grammar pass candidates through untouched (the lazy fast path);
+/// every other mode still runs, so `Deny` reserved-token protection,
+/// truncation samplers, and mirostat behave identically on both paths.
 fn apply_modes<M: crate::backend::Model + Sync>(
     candidates: Candidates,
     opts: &SamplerConfig,
@@ -1577,7 +1593,23 @@ fn apply_modes<M: crate::backend::Model + Sync>(
         rng,
         ..
     } = &mut *state;
-    let mut candidates = opts.modes.iter().zip(matchers.iter()).fold(
+    // Deferred grammar first — same position the session gives an
+    // eager grammar. See this function's docs for why running it after
+    // the truncation samplers is a correctness bug, not a preference.
+    let candidates = if !skip_constraints {
+        match (deferred.as_ref(), opts.deferred_grammar.as_ref()) {
+            (Some(d), Some(spec)) if d.active => grammar::grammar_filter(
+                candidates,
+                &spec.grammar,
+                &d.matcher,
+                model,
+            ),
+            _ => candidates,
+        }
+    } else {
+        candidates
+    };
+    let candidates = opts.modes.iter().zip(matchers.iter()).fold(
         candidates,
         |candidates, (mode, matcher)| {
             if skip_constraints
@@ -1653,20 +1685,6 @@ fn apply_modes<M: crate::backend::Model + Sync>(
             }
         },
     );
-    if !skip_constraints {
-        if let (Some(d), Some(spec)) =
-            (deferred.as_ref(), opts.deferred_grammar.as_ref())
-        {
-            if d.active {
-                candidates = grammar::grammar_filter(
-                    candidates,
-                    &spec.grammar,
-                    &d.matcher,
-                    model,
-                );
-            }
-        }
-    }
     candidates
 }
 
@@ -2933,6 +2951,64 @@ mod tests {
         state.reset_constraints(&opts);
         let d = state.deferred.as_ref().expect("config has a deferred");
         assert!(!d.active, "deferred must return to inactive");
+    }
+
+    /// A truncation sampler must not be able to starve the deferred
+    /// grammar (#76).
+    ///
+    /// The deferred grammar runs *before* the mode chain, exactly like
+    /// an eager grammar (which the session prepends into `modes`).
+    /// When it ran last it only saw what truncation left behind — here
+    /// `TopK { k: 1 }` keeps just the highest-logit token — and if that
+    /// lone survivor was illegal the filter force-EOS'd, ending
+    /// generation mid-structure even though a legal token (`A`) was
+    /// present in the full candidate set.
+    ///
+    /// Both sampling paths are pinned: the masked path
+    /// (`lazy_grammar: false`) and the lazy fast path
+    /// (`lazy_grammar: true`), whose rejection fallback reruns this
+    /// same function with masking on. Production runs the lazy path.
+    #[test]
+    fn deferred_grammar_survives_truncation_sampler() {
+        for lazy in [false, true] {
+            let deferred = crate::DeferredGrammar {
+                grammar: CompiledGrammar::parse(AB_GRAMMAR).unwrap(),
+                activate_after: vec![b"!".to_vec()],
+                feed_trigger: false,
+            };
+            let opts = SamplerConfig {
+                modes: vec![SamplingMode::TopK {
+                    k: NonZeroUsize::new(1).unwrap(),
+                }],
+                repetition: None,
+                deferred_grammar: Some(deferred),
+                lazy_grammar: lazy,
+                ..SamplerConfig::default()
+            };
+            let mut state = state_for(&opts);
+            state
+                .deferred
+                .as_mut()
+                .expect("config has a deferred")
+                .active = true;
+
+            // `X` ("x") outranks `A` ("a") on logits, but only `A`
+            // extends `root ::= "ab"` from the root state.
+            let picked =
+                sample(cands(&[(X, 10.0), (A, 5.0)]), &opts, &mut state);
+
+            assert_eq!(
+                picked, A,
+                "lazy={lazy}: the grammar must mask before TopK narrows, \
+                 not after — got {picked} (EOS={EOS}) instead of the one \
+                 legal token"
+            );
+            assert_ne!(
+                picked, EOS,
+                "lazy={lazy}: force-EOS while a legal token existed is the \
+                 #76 failure — generation dies mid-structure"
+            );
+        }
     }
 
     /// A populated mid-call snapshot round-trips the constrained


### PR DESCRIPTION
Fixes #76.

## Root cause

An **eager** grammar (forced `tool_choice`) is prepended into `SamplerConfig::modes` by the session, so it masks the full vocab *before* `LocallyTypical` / `TopP` / `TopK` narrow it.

The **deferred** grammar (`tool_choice: auto`) is not in `modes` — it lives in `SamplerConfig::deferred_grammar` — and `apply_modes` applied it *after* the entire fold. So it only ever saw what truncation left behind. With this repo's gpt-oss sidecar (`LocallyTypical p=0.5`) that is frequently a **single** token. When that lone survivor was illegal, `grammar_filter` hit zero candidates, force-EOS'd, and generation ended mid-structure — surfacing as `SessionError::GrammarViolation` — even though thousands of legal tokens existed in the full candidate set.

The failing signature from the debug log, right at the violation:

```
{'candidates_in': 2, 'bitmap_pass': 1, 'kept': 1}
{'candidates_in': 1, 'bitmap_pass': 0, 'kept': 0}   <-- force-EOS
```

`bitmap_pass: 0` — the first-byte bitmap rejected the only candidate present.

## Why it looked the way it did in #76

- **Auto-only.** Only `tool_choice: auto` builds a deferred grammar; forced tool choice takes the eager path and was never affected. (This is also why switching to `Any` "fixes" it.)
- **Intermittent.** Depends on whether the typical set happens to retain a grammar-legal token.
- **Budget-independent.** Reproduced identically at `max_tokens` 2048 / 4096 / 8192 / 16384 — consistent with the report that raising the budget changed nothing.

Note this supersedes my earlier comment on #76 suggesting unmasked stop tokens. The EOG mask (`e79dd2d`) is correct and was not involved.

## Fix

`apply_modes` runs the deferred grammar first, at the same point an eager grammar runs. The lazy fast path is unchanged: `skip_constraints` still bypasses both, and its rejection fallback reruns this same function with masking on — now with the correct ordering, so the fallback can actually find a legal token instead of force-EOS'ing.

## Verification

Reproduced end-to-end on `gpt-oss-20b-UD-Q8_K_XL` (CUDA, RTX 3090) through a multi-round agentic tool session shaped like the Agora seed runner — large cached system prefix, tool results fed back each round:

- **Before:** failed on the first acting round, 2/2 attempts.
- **After:** 8/8 rounds clean, `stop_reason: tool_use` every round.

`deferred_grammar_survives_truncation_sampler` pins both sampling paths (`lazy_grammar` false and true) using `TopK { k: 1 }` as the starving truncation mode. Reverting only the ordering change makes it fail with exactly the production symptom:

```
assertion `left == right` failed: lazy=false: the grammar must mask before
TopK narrows, not after — got 0 (EOS=0) instead of the one legal token
```

`just check` passes (fmt, clippy `-D warnings`, tests, doctests, badge). Badge 603 → 604; version 0.8.1 → 0.8.2.

## Not addressed here

The Qwen3.6 Hermes-`<tool_call>`-XML-as-text signature in #76 looks like a separate chat-template/tool-format mismatch. I'd suggest splitting it into its own issue rather than closing it with this.

Co-authored-by: Claude <claude@anthropic.com>