### PR TITLE
test(cuda): fail loudly when a cuda build finds no GPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,8 +289,9 @@ jobs:
       # compares them against `cargo nextest list` so they cannot drift
       # silently (`scripts/test.py badge --fix` rewrites them). The
       # binaries are already built by the step above, so the list is
-      # nearly free. No test is cuda-gated, so the cpu config's counts
-      # equal the default config's the README describes.
+      # nearly free. No test gates its `#[test]` attribute on a feature
+      # — backend-specific tests gate their body instead — so the cpu
+      # config's counts equal the default config's the README describes.
       - run: python3 scripts/test.py badge -c llama-cpp-cpu
       # Named exactly, not the whole directory: `clean: false` means
       # `target/test-logs/` accumulates every mode this box has ever run,
@@ -345,8 +346,13 @@ jobs:
       # harness records llama.cpp's own view of the machine, but nothing
       # in-process can see the driver version — this is where it comes
       # from. Job logs age out; the artifact rides with the run.
+      #
+      # `pipefail` is load-bearing: the default `bash -e` takes its status
+      # from `tee`, so the driver-mismatch state this step exists to record
+      # — where `nvidia-smi` fails outright — used to sail through green.
       - name: gpu
         run: |
+          set -o pipefail
           mkdir -p target/test-logs
           nvidia-smi | tee target/test-logs/nvidia-smi.txt
       - name: link model weights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Set `DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1` to exercise the CPU path
   deliberately — a legitimate thing to want; silently getting it is not.
 
+  The test's `cuda` gate is on its **body**, not on `#[test]`, so it is
+  listed in every configuration and `nextest list` returns the same count
+  everywhere. Gating the attribute makes README.md's hand-counted numbers
+  mean one thing under `llama-cpp` (605) and another under
+  `llama-cpp-cpu` (604) — which is how this PR first went red. House rule
+  now, and the reason `just check` can verify the badge against whichever
+  target dir is warm instead of building the cpu one.
+
+- **A `nvidia-smi` preflight on `test.py run`** for `cuda` configurations
+  on Linux. Reaches the same verdict as the test above roughly 40 minutes
+  earlier — before a cold cuda build rather than after it. It is not a
+  replacement: a working `nvidia-smi` says nothing about a llama.cpp that
+  cmake quietly configured without CUDA, so ggml's own device list stays
+  the authority. Honours `DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1`.
+
+### Fixed
+
+- **The pre-commit hook actually gates the README badge now.** 6d4a9e2
+  put that gate in `scripts/test.py check` and claimed the hook was
+  covered; it was not. The hook runs `just check`, whereas that function
+  is `just permutations` — which the hook deliberately skips as too slow
+  — so the gate never ran once, and a stale badge reached CI in #82. It
+  lives in the `just check` recipe now.
+
+- **CI's `gpu` step no longer swallows a failing `nvidia-smi`.** It pipes
+  into `tee` under the default `bash -e`, which takes its status from
+  `tee`, so the exact driver-mismatch state the step exists to record
+  reported green. It sets `pipefail` now.
+
 ## [0.8.2] — 2026-07-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this crate are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] — 2026-07-25
+
+### Added
+
+- **`llama_cpp::gpu_device_names`** — the GPU-class compute devices ggml
+  actually discovered, as opposed to the ones the build asked for. Those
+  differ in a way nothing else reported: a `feature = "cuda"` build links
+  CUDA and then silently runs every model on the CPU when the driver is
+  unusable, and from inside the process that is indistinguishable from a
+  box with no card.
+
+- **A test asserting a `cuda` build found a GPU.** The model tier stays
+  **green** through CPU fallback — correctness doesn't depend on the
+  device — and timing doesn't give it away either, because only the
+  generation-heavy tests slow down while load-dominated ones get *faster*
+  (no VRAM upload, weights already in page cache). The suite's wall clock
+  can therefore move in either direction, which makes an explicit device
+  assertion the only reliable signal.
+
+  Caught for real on 2026-07-25: an unattended upgrade of
+  `nvidia-driver-580-server` (580.159.03 → 580.173.02) left the old kernel
+  module loaded against new userspace libraries. `nvidia-smi` failed
+  outright, `cuInit` returned 804 (`CUDA_ERROR_SYSTEM_DRIVER_MISMATCH`),
+  ggml found zero CUDA devices, and the entire model tier passed on the
+  CPU with nothing in CI saying so. The new test fails in 0.04 s and names
+  the diagnosis.
+
+  Set `DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1` to exercise the CPU path
+  deliberately — a legitimate thing to want; silently getting it is not.
+
 ## [0.8.2] — 2026-07-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drama_llama"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 # The stable toolchain CI actually tests (nothing older is ever built
 # here, so a lower claim would be untested). Bump freely alongside CI's

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/mdegans/drama_llama/actions/workflows/ci.yml/badge.svg)](https://github.com/mdegans/drama_llama/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/mdegans/drama_llama/graph/badge.svg)](https://codecov.io/gh/mdegans/drama_llama)
-[![tests](https://img.shields.io/badge/tests-604-blue)](#testing)
+[![tests](https://img.shields.io/badge/tests-605-blue)](#testing)
 [![license](https://img.shields.io/badge/license-RAIL--S-lightgrey)](https://github.com/mdegans/drama_llama/blob/main/LICENSE.md)
 
 `drama_llama` runs language models on your own hardware behind an API shaped
@@ -207,7 +207,7 @@ sampler-settings editor).
 
 ## Testing
 
-604 tests across 27 binaries in the default configuration — 485 that run in
+605 tests across 27 binaries in the default configuration — 486 that run in
 seconds and 119 that load real weights onto a real accelerator. The
 model-backed tier is `#[ignore]`d so the fast loop stays fast, and the whole
 topology — *which features* × *which tests* — lives in one place,

--- a/justfile
+++ b/justfile
@@ -219,6 +219,15 @@ doctest config="llama-cpp":
 # a warm build, which is well inside this recipe's budget. They are load-bearing
 # now that the crate root is `#![doc = include_str!("../README.md")]`: the
 # README's examples are the only thing keeping the front page honest.
+#
+# `just badge` is in here — this is the recipe the pre-commit hook runs, and
+# 6d4a9e2 put that gate in `scripts/test.py check` (`just permutations`)
+# instead, which the hook deliberately does not run, so a stale badge sailed
+# through to CI in #82. It costs a `nextest list` in the same target dir and
+# feature set as `just test`, which the hook runs immediately after — so the
+# test binaries it builds are the ones that run a moment later, not a second
+# build. The counts do not vary by configuration (see `cuda_build_has_a_gpu_
+# device`), so there is no need to reach for the cpu config the way CI does.
 check:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -230,6 +239,8 @@ check:
     just doctest
     echo "+ just clippy (-D warnings)"
     just clippy
+    echo "+ just badge (README counts)"
+    just badge
     echo "check: ok"
 
 # Point git at the versioned hooks in .githooks/ — one config line, no copying,

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -421,6 +421,51 @@ def selection(
     return tier, extra, name
 
 
+def preflight_gpu(features: list[str]) -> int:
+    """Fail a `cuda` run before the build if the driver is unusable.
+
+    Strictly a fast path to the same verdict
+    `llama_cpp::tests::cuda_build_has_a_gpu_device` reaches — that test
+    asks ggml what this build actually found and stays the authority,
+    because a `nvidia-smi` that works proves nothing about a llama.cpp
+    that cmake quietly configured without CUDA. What this buys is the
+    ~40 minutes between "start a cold cuda build" and "watch the model
+    tier pass on the CPU": an unusable driver reports here in two
+    seconds.
+
+    `DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1` skips it, same as the test.
+    """
+    if "cuda" not in features or platform.system() != "Linux":
+        return 0
+    if os.environ.get("DRAMA_LLAMA_ALLOW_CPU_FALLBACK"):
+        print("= preflight: CPU fallback allowed — skipping", flush=True)
+        return 0
+    if shutil.which("nvidia-smi") is None:
+        print(
+            "preflight: built with `cuda` but no `nvidia-smi` on PATH.\n"
+            "Set DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1 to run on the CPU anyway.",
+            file=sys.stderr,
+        )
+        return 1
+    probe = subprocess.run(
+        ["nvidia-smi"], capture_output=True, text=True, check=False
+    )
+    if probe.returncode != 0:
+        print(
+            "preflight: `nvidia-smi` failed — the driver is unusable, so a "
+            "`cuda` build will silently run every model test on the CPU.\n"
+            "\n"
+            f"{(probe.stderr or probe.stdout).strip()}\n"
+            "\n"
+            "An unattended driver upgrade with the old kernel module still "
+            "loaded needs a reboot (or an nvidia module reload).\n"
+            "Set DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1 to run on the CPU anyway.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     if not DRY_RUN:
         require_nextest()
@@ -430,6 +475,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         config, "all" if args.filter else args.tier, args.moeflux_model
     )
     features = config.feature_list(args.moeflux_model)
+    if not DRY_RUN:
+        rc = preflight_gpu(features)
+        if rc != 0:
+            return rc
     tier, extra, name = selection(config, args)
 
     cmd = [
@@ -743,14 +792,15 @@ def cmd_check(args: argparse.Namespace) -> int:
     That is `doctest`'s job, and it is why that subcommand sweeps
     configurations too rather than running just one.
 
-    Since 2026-07-24 this also runs the `badge` verification (the
-    llama-cpp-cpu configuration, same as CI's badge step), so a stale
-    README test count fails at the pre-commit hook instead of ~40
-    minutes later in CI — the 0.8.1 PR hit exactly that. On a warm
-    tree `cargo nextest list` is near-free; on a cold tree it builds
-    the cpu test binaries once, which is the price of the gate.
+    The `badge` verification is deliberately NOT here. It was added
+    here on 2026-07-24 (6d4a9e2) on the theory that this gated the
+    pre-commit hook — it does not. The hook runs `just check`; this is
+    `just permutations`, which the hook skips as too slow, so the gate
+    never ran and a stale badge reached CI in #82. It lives in the
+    `just check` recipe now, and CI runs `badge` as its own step after
+    the test job.
     """
-    rc = sweep(
+    return sweep(
         "check",
         selected_configs(args.config, args.moeflux_model, args.ci),
         lambda features: [
@@ -761,15 +811,6 @@ def cmd_check(args: argparse.Namespace) -> int:
             "--features",
             ",".join(features),
         ],
-    )
-    if rc != 0:
-        return rc
-    return cmd_badge(
-        argparse.Namespace(
-            config="llama-cpp-cpu",
-            moeflux_model=args.moeflux_model,
-            fix=False,
-        )
     )
 
 
@@ -907,12 +948,18 @@ def cmd_badge(args: argparse.Namespace) -> int:
     configuration the numbers describe, and `--fix` rewrites them.
 
     CI runs this after the test job (the test binaries are already
-    built, so the list is nearly free). Since 2026-07-24 `check` runs
-    it too — the pre-commit hook is now gated on it, a deliberate
-    reversal of the original "keep the hook fast" exclusion after a
-    stale badge failed the 0.8.1 PR in CI. `nextest list` on a warm
-    target dir keeps the hook cheap; a cold tree pays one cpu-config
-    test-binary build.
+    built, so the list is nearly free), and the `just check` recipe
+    runs it, which is what puts it in front of every commit — a
+    deliberate reversal of the original "keep the hook fast" exclusion
+    after a stale badge failed the 0.8.1 PR in CI.
+
+    The counts are the same in every configuration, so the hook can
+    verify them against whichever target dir is already warm rather
+    than building a second one. That invariant is a house rule, not an
+    accident: a backend-specific test puts its `cfg` on the **body**,
+    never on `#[test]` (see `cuda_build_has_a_gpu_device`). Gate the
+    attribute and the badge means one number under `llama-cpp` and
+    another under `llama-cpp-cpu` — #82 went red exactly that way.
     """
     import json as _json
     import re as _re

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,9 @@ pub use dialect::CallSyntax;
 mod llama_cpp;
 #[cfg(feature = "llama-cpp")]
 pub use llama_cpp::{
-    llama_quantize, DecodeError, FlashAttention, LlamaCppBackend,
-    LlamaCppDecoder, LlamaCppEngine, LlamaCppModel, LlamaCppOptions, NewError,
+    gpu_device_names, llama_quantize, DecodeError, FlashAttention,
+    LlamaCppBackend, LlamaCppDecoder, LlamaCppEngine, LlamaCppModel,
+    LlamaCppOptions, NewError,
 };
 #[cfg(feature = "mtmd")]
 pub use llama_cpp::{Mtmd, MtmdParams};

--- a/src/llama_cpp/mod.rs
+++ b/src/llama_cpp/mod.rs
@@ -18,6 +18,52 @@ pub use model::{llama_quantize, LlamaCppModel};
 pub use mtmd::{Mtmd, MtmdParams};
 pub use options::LlamaCppOptions;
 
+/// Names of the GPU-class compute devices ggml discovered, in registry
+/// order. Empty means every model will run on the CPU.
+///
+/// This asks ggml what it actually found rather than what the build
+/// requested, and those differ in ways nothing else reports. A build with
+/// `feature = "cuda"` links CUDA and still silently falls back to the CPU
+/// when the driver is unusable — a kernel module that no longer matches
+/// the userspace libraries (`cuInit` → `CUDA_ERROR_SYSTEM_DRIVER_MISMATCH`,
+/// the state an unattended driver upgrade leaves behind until reboot) is
+/// indistinguishable, from inside the process, from a box with no card.
+///
+/// Only `GPU` counts. `ACCEL` and `IGPU` are deliberately excluded: the
+/// question this answers is "did the discrete accelerator this build was
+/// compiled for actually show up", and an integrated fallback is a no.
+pub fn gpu_device_names() -> Vec<String> {
+    // Safety: the backend registry is initialized on first access inside
+    // ggml and is read-only thereafter. `dev_get` is in range by the
+    // `dev_count` bound, and `dev_name` returns a borrowed static C string
+    // owned by the device, which we copy before returning.
+    unsafe {
+        let count = llama_cpp_sys_3::ggml_backend_dev_count();
+        (0..count)
+            .filter_map(|i| {
+                let dev = llama_cpp_sys_3::ggml_backend_dev_get(i);
+                if dev.is_null() {
+                    return None;
+                }
+                if llama_cpp_sys_3::ggml_backend_dev_type(dev)
+                    != llama_cpp_sys_3::ggml_backend_dev_type_GGML_BACKEND_DEVICE_TYPE_GPU
+                {
+                    return None;
+                }
+                let name = llama_cpp_sys_3::ggml_backend_dev_name(dev);
+                if name.is_null() {
+                    return None;
+                }
+                Some(
+                    std::ffi::CStr::from_ptr(name)
+                        .to_string_lossy()
+                        .into_owned(),
+                )
+            })
+            .collect()
+    }
+}
+
 /// Tag for the llama-cpp [`Backend`]. Use as a type parameter for [`Engine`] or
 /// [`Session`].
 ///
@@ -58,5 +104,62 @@ impl Backend for LlamaCppBackend {
     fn clear_log_callback() -> Result<(), crate::backend::NotImplemented> {
         crate::log::clear_log_callback();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// A `cuda` build that quietly ran on the CPU is a broken box, not a
+    /// passing test run.
+    ///
+    /// ggml falls back to the CPU whenever the CUDA driver is unusable, and
+    /// the model tier stays **green** through it — correctness does not
+    /// depend on the device. Timing does not give it away either: only
+    /// generation-heavy tests slow down, while load-dominated ones get
+    /// *faster* (no VRAM upload, and the weights are already in page
+    /// cache), so the suite's wall clock can move either direction. That
+    /// makes an explicit device assertion the only reliable signal.
+    ///
+    /// The state this catches, seen 2026-07-25: an unattended upgrade of
+    /// `nvidia-driver-580-server` (580.159.03 → 580.173.02) left the old
+    /// kernel module loaded against new userspace libraries. `nvidia-smi`
+    /// failed outright, `cuInit` returned 804
+    /// (`CUDA_ERROR_SYSTEM_DRIVER_MISMATCH`), ggml found zero CUDA
+    /// devices — and the whole model tier passed on the CPU. Reboot fixes
+    /// it; nothing in CI said so.
+    ///
+    /// Set `DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1` to exercise the CPU path on
+    /// purpose. That is a legitimate thing to want; silently getting it is
+    /// not. Note the CPU path is far slower on the generation-heavy tests
+    /// (`whodunit` and friends), so expect the ignored tier to crawl.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn cuda_build_has_a_gpu_device() {
+        if std::env::var_os("DRAMA_LLAMA_ALLOW_CPU_FALLBACK").is_some() {
+            eprintln!(
+                "cuda_build_has_a_gpu_device: DRAMA_LLAMA_ALLOW_CPU_FALLBACK \
+                 set — skipping (CPU path is intentional)"
+            );
+            return;
+        }
+
+        let gpus = super::gpu_device_names();
+        assert!(
+            !gpus.is_empty(),
+            "built with `feature = \"cuda\"` but ggml found no GPU device — \
+             every model test will silently run on the CPU.\n\
+             \n\
+             Most likely the driver is unusable rather than absent. Check:\n\
+             \n\
+             \tnvidia-smi                # NVML mismatch reports here first\n\
+             \tcat /proc/driver/nvidia/version   # loaded kernel module\n\
+             \tls /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.*  # userspace\n\
+             \n\
+             A driver upgrade with the old module still loaded needs a \
+             reboot (or an nvidia module reload).\n\
+             \n\
+             Testing the CPU path deliberately? \
+             Set DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1."
+        );
     }
 }

--- a/src/llama_cpp/mod.rs
+++ b/src/llama_cpp/mod.rs
@@ -132,34 +132,52 @@ mod tests {
     /// purpose. That is a legitimate thing to want; silently getting it is
     /// not. Note the CPU path is far slower on the generation-heavy tests
     /// (`whodunit` and friends), so expect the ignored tier to crawl.
-    #[cfg(feature = "cuda")]
+    ///
+    /// The `cuda` gate is on the **body**, not on `#[test]`, so the test is
+    /// listed in every configuration and `nextest list` returns the same
+    /// count everywhere. That keeps README.md's hand-counted numbers
+    /// config-independent — gating the attribute instead makes the badge
+    /// mean one thing under `llama-cpp` and another under `llama-cpp-cpu`,
+    /// which is how #82 went red. Same rule for any future
+    /// backend-specific test.
     #[test]
     fn cuda_build_has_a_gpu_device() {
-        if std::env::var_os("DRAMA_LLAMA_ALLOW_CPU_FALLBACK").is_some() {
-            eprintln!(
-                "cuda_build_has_a_gpu_device: DRAMA_LLAMA_ALLOW_CPU_FALLBACK \
-                 set — skipping (CPU path is intentional)"
-            );
-            return;
-        }
-
-        let gpus = super::gpu_device_names();
-        assert!(
-            !gpus.is_empty(),
-            "built with `feature = \"cuda\"` but ggml found no GPU device — \
-             every model test will silently run on the CPU.\n\
-             \n\
-             Most likely the driver is unusable rather than absent. Check:\n\
-             \n\
-             \tnvidia-smi                # NVML mismatch reports here first\n\
-             \tcat /proc/driver/nvidia/version   # loaded kernel module\n\
-             \tls /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.*  # userspace\n\
-             \n\
-             A driver upgrade with the old module still loaded needs a \
-             reboot (or an nvidia module reload).\n\
-             \n\
-             Testing the CPU path deliberately? \
-             Set DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1."
+        #[cfg(not(feature = "cuda"))]
+        eprintln!(
+            "cuda_build_has_a_gpu_device: not a `cuda` build — nothing to \
+             assert"
         );
+
+        #[cfg(feature = "cuda")]
+        {
+            if std::env::var_os("DRAMA_LLAMA_ALLOW_CPU_FALLBACK").is_some() {
+                eprintln!(
+                    "cuda_build_has_a_gpu_device: \
+                     DRAMA_LLAMA_ALLOW_CPU_FALLBACK set — skipping (CPU path \
+                     is intentional)"
+                );
+                return;
+            }
+
+            let gpus = super::gpu_device_names();
+            assert!(
+                !gpus.is_empty(),
+                "built with `feature = \"cuda\"` but ggml found no GPU \
+                 device — every model test will silently run on the CPU.\n\
+                 \n\
+                 Most likely the driver is unusable rather than absent. \
+                 Check:\n\
+                 \n\
+                 \tnvidia-smi                # NVML mismatch reports here first\n\
+                 \tcat /proc/driver/nvidia/version   # loaded kernel module\n\
+                 \tls /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.*  # userspace\n\
+                 \n\
+                 A driver upgrade with the old module still loaded needs a \
+                 reboot (or an nvidia module reload).\n\
+                 \n\
+                 Testing the CPU path deliberately? \
+                 Set DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1."
+            );
+        }
     }
 }


### PR DESCRIPTION
**Stacked on #79** — shows 2 commits until that merges, then I'll rebase so only this one remains. Stacked deliberately: the badge count and version both follow from #79 (604 → 605, 0.8.2 → 0.8.3), so basing on `main` would have produced conflicting numbers.

## The blind spot

A `feature = "cuda"` build links CUDA and then silently runs every model on the **CPU** when the driver is unusable. From inside the process that's indistinguishable from a box with no card, and the model tier stays **green** — correctness doesn't depend on the device.

Timing doesn't give it away either, which is what makes this worth a test rather than a habit. Only generation-heavy tests slow down; load-dominated ones get *faster* (no VRAM upload, weights already in page cache). The suite's wall clock can move in either direction, so an explicit device assertion is the only reliable signal.

## Caught for real, today

An unattended upgrade of `nvidia-driver-580-server` (580.159.03 → 580.173.02) left the old kernel module loaded against new userspace libraries:

- `nvidia-smi` → `Failed to initialize NVML: Driver/library version mismatch`
- `cuInit` → **804** (`CUDA_ERROR_SYSTEM_DRIVER_MISMATCH`)
- `ggml_cuda_init` → zero devices
- the entire model tier → **passed**, on the CPU, with nothing in CI saying so

It was found by eye, not by CI, and only because `nvidia-smi` happened to get run.

## The check

`gpu_device_names()` asks ggml what it *discovered* rather than what the build *requested*. Only `GPU`-class devices count — `ACCEL` and `IGPU` are excluded, since the question is whether the discrete accelerator this build was compiled for actually showed up, and an integrated fallback is a no.

It's a plain unit test in the fast tier: no model load, no weights, runs in hundredths of a second.

## Verified in both states, same box, same session

| driver state | result |
|---|---|
| mismatched module | **FAIL in 0.04s**, message names the diagnosis |
| after `nvidia` module reload | **PASS in 0.07s**, `ggml_cuda_init: found 1 CUDA devices` |
| `DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1` | skips |

The failure message:

```
built with `feature = "cuda"` but ggml found no GPU device — every model test
will silently run on the CPU.

Most likely the driver is unusable rather than absent. Check:

	nvidia-smi                # NVML mismatch reports here first
	cat /proc/driver/nvidia/version   # loaded kernel module
	ls /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.*  # userspace

A driver upgrade with the old module still loaded needs a reboot (or an nvidia
module reload).

Testing the CPU path deliberately? Set DRAMA_LLAMA_ALLOW_CPU_FALLBACK=1.
```

The escape hatch exists because exercising the CPU path on purpose is legitimate — silently getting it is not. Worth knowing it's slow on the generation-heavy tests: `json_integration_lazy_grammar` is ~30s here on 32 cores versus ~120s on the mac's 8 perf cores.

`just check` passes. Badge 604 → 605, version 0.8.2 → 0.8.3.

Co-authored-by: Claude <claude@anthropic.com>